### PR TITLE
feat(build): add workflow_dispatch event trigger

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,6 +1,7 @@
 name: Test Code (Style, Tests)
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
     branches: [ main ]

--- a/core/federated-catalog/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCacheStoreTest.java
+++ b/core/federated-catalog/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCacheStoreTest.java
@@ -24,6 +24,8 @@ import org.eclipse.edc.util.concurrency.LockManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +50,8 @@ class InMemoryFederatedCacheStoreTest {
                 .id(id)
                 .asset(asset)
                 .policy(Policy.Builder.newInstance().build())
+                .contractStart(ZonedDateTime.now())
+                .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                 .build();
     }
 

--- a/core/federated-catalog/src/test/java/org/eclipse/edc/catalog/query/BatchedRequestFetcherTest.java
+++ b/core/federated-catalog/src/test/java/org/eclipse/edc/catalog/query/BatchedRequestFetcherTest.java
@@ -26,6 +26,8 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -94,6 +96,8 @@ class BatchedRequestFetcherTest {
                         .id("id" + i)
                         .policy(Policy.Builder.newInstance().build())
                         .asset(Asset.Builder.newInstance().id("asset" + i).build())
+                        .contractStart(ZonedDateTime.now())
+                        .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                         .build())
                 .collect(Collectors.toList());
 

--- a/core/federated-catalog/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/federated-catalog/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -22,6 +22,8 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 
@@ -39,6 +41,8 @@ public class TestUtil {
                 .id(id)
                 .asset(Asset.Builder.newInstance().id(id).build())
                 .policy(Policy.Builder.newInstance().build())
+                .contractStart(ZonedDateTime.now())
+                .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                 .build();
     }
 

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
@@ -11,6 +11,8 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -57,6 +59,8 @@ public class TestFunctions {
                 .id(id)
                 .asset(Asset.Builder.newInstance().id(id).build())
                 .policy(Policy.Builder.newInstance().build())
+                .contractStart(ZonedDateTime.now())
+                .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                 .build();
     }
 

--- a/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
+++ b/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
@@ -22,5 +22,6 @@ dependencies {
     testImplementation(libs.awaitility)
     testImplementation(libs.okhttp)
     testImplementation(edc.junit)
+    testRuntimeOnly(libs.jackson.datatypeJsr310)
 }
 

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -1,12 +1,14 @@
 package org.eclipse.edc.end2end;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.eclipse.edc.api.model.CriterionDto;
 import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -22,7 +24,15 @@ import static org.eclipse.edc.end2end.TestFunctions.createPolicy;
 
 @EndToEndTest
 class FederatedCatalogTest {
-    private final ManagementApiClient apiClient = new ManagementApiClient(new ObjectMapper());
+    private final ManagementApiClient apiClient = createManagementClient();
+
+    @NotNull
+    private static ManagementApiClient createManagementClient() {
+        var mapper = new ObjectMapper();
+        //needed for ZonedDateTime
+        mapper.registerModule(new JavaTimeModule());
+        return new ManagementApiClient(mapper);
+    }
 
     @Test
     void crawl_whenOfferAvailable_shouldContainOffer(TestInfo testInfo) {


### PR DESCRIPTION
## What this PR changes/adds

Adds the `workflow_dispatch` event trigger to `verify.yaml`

## Why it does that

to be able to trigger the build from external systems through the Github API (e.g. Jenkins).

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Connector/issues/2281

## Additional Notes
- fixed some NPE's in the tests, that were introduced by recent changes in the connector.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
