### PR TITLE
chore: upgrade to Gradle 8.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/launchers/build.gradle.kts
+++ b/launchers/build.gradle.kts
@@ -15,7 +15,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/end2end-test/catalog-runtime/build.gradle.kts
+++ b/system-tests/end2end-test/catalog-runtime/build.gradle.kts
@@ -15,7 +15,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/end2end-test/connector-runtime/build.gradle.kts
+++ b/system-tests/end2end-test/connector-runtime/build.gradle.kts
@@ -15,7 +15,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -3,7 +3,7 @@ package org.eclipse.edc.end2end;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.eclipse.edc.api.model.CriterionDto;
-import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionCreateDto;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.result.Result;
@@ -47,7 +47,7 @@ class FederatedCatalogTest {
         var pr = apiClient.postPolicy(policy);
         assertThat(r.succeeded()).withFailMessage(getError(pr)).isTrue();
 
-        var def = ContractDefinitionRequestDto.Builder.newInstance().id("def-" + id)
+        var def = ContractDefinitionCreateDto.Builder.newInstance().id("def-" + id)
                 .accessPolicyId(policyId)
                 .contractPolicyId(policyId)
                 .criteria(List.of(CriterionDto.from(Asset.PROPERTY_ID, "=", id)))

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
@@ -1,7 +1,7 @@
 package org.eclipse.edc.end2end;
 
+import org.eclipse.edc.connector.api.management.asset.model.AssetCreationRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
-import org.eclipse.edc.connector.api.management.asset.model.AssetRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionRequestDto;
 import org.eclipse.edc.policy.model.Policy;
@@ -12,7 +12,7 @@ import java.util.Map;
 public class TestFunctions {
     public static AssetEntryDto createAsset(String id) {
         return AssetEntryDto.Builder.newInstance()
-                .asset(AssetRequestDto.Builder.newInstance()
+                .asset(AssetCreationRequestDto.Builder.newInstance()
                         .id(id)
                         .properties(Map.of(
                                 Asset.PROPERTY_CONTENT_TYPE, "application/octet-stream",


### PR DESCRIPTION
## What this PR changes/adds

Upgrades to Gradle v 8.0

## Why it does that

To keep in step with current developments, avoid technical debt.

## Further notes

.
## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
