### PR TITLE
chore: adapt code to fit to the latest connector upstream

### DIFF
--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/BatchedRequestFetcher.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/BatchedRequestFetcher.java
@@ -56,7 +56,7 @@ public class BatchedRequestFetcher {
         var range = new Range(from, from + batchSize);
         var rq = catalogRequest.toBuilder().querySpec(QuerySpec.Builder.newInstance().range(range).build()).build();
 
-        return dispatcherRegistry.send(Catalog.class, rq, () -> null)
+        return dispatcherRegistry.send(Catalog.class, rq)
                 .thenApply(Catalog::getContractOffers)
                 .thenCompose(offers -> {
                     if (offers.size() > 0) {

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/BatchedRequestFetcherTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/BatchedRequestFetcherTest.java
@@ -55,7 +55,7 @@ class BatchedRequestFetcherTest {
 
     @Test
     void fetchAll() {
-        when(dispatcherMock.send(eq(Catalog.class), any(CatalogRequest.class), any()))
+        when(dispatcherMock.send(eq(Catalog.class), any(CatalogRequest.class)))
                 .thenReturn(completedFuture(createCatalog(5)))
                 .thenReturn(completedFuture(createCatalog(5)))
                 .thenReturn(completedFuture(createCatalog(3)))
@@ -69,7 +69,7 @@ class BatchedRequestFetcherTest {
 
 
         var captor = forClass(CatalogRequest.class);
-        verify(dispatcherMock, times(4)).send(eq(Catalog.class), captor.capture(), any());
+        verify(dispatcherMock, times(4)).send(eq(Catalog.class), captor.capture());
 
         // verify the sequence of requests
         assertThat(captor.getAllValues())

--- a/extensions/store/fcc-node-directory-cosmos/src/main/java/org/eclipse/edc/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectory.java
+++ b/extensions/store/fcc-node-directory-cosmos/src/main/java/org/eclipse/edc/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectory.java
@@ -61,6 +61,6 @@ public class CosmosFederatedCacheNodeDirectory implements FederatedCacheNodeDire
         Objects.requireNonNull(node.getName(), "FederatedCacheNode must have a name!");
 
         var document = new FederatedCacheNodeDocument(node, partitionKey);
-        with(retryPolicy).run(() -> cosmosDbApi.saveItem(document));
+        with(retryPolicy).run(() -> cosmosDbApi.createItem(document));
     }
 }

--- a/extensions/store/fcc-node-directory-cosmos/src/test/java/org/eclipse/edc/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryTest.java
+++ b/extensions/store/fcc-node-directory-cosmos/src/test/java/org/eclipse/edc/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryTest.java
@@ -70,14 +70,14 @@ class CosmosFederatedCacheNodeDirectoryTest {
     @Test
     void insert() {
         FederatedCacheNode node = createNode();
-        api.saveItem(any(FederatedCacheNodeDocument.class));
+        api.createItem(any(FederatedCacheNodeDocument.class));
 
         List<FederatedCacheNodeDocument> documents = new ArrayList<>();
         doAnswer(i -> {
             FederatedCacheNodeDocument passedNode = i.getArgument(0);
             documents.add(passedNode);
             return null;
-        }).when(api).saveItem(any(FederatedCacheNodeDocument.class));
+        }).when(api).createItem(any(FederatedCacheNodeDocument.class));
 
         directory.insert(node);
 
@@ -87,7 +87,7 @@ class CosmosFederatedCacheNodeDirectoryTest {
                     assertThat(doc.getPartitionKey()).isEqualTo(PARTITION_KEY);
                     assertNodesAreEqual(doc.getWrappedInstance(), node);
                 });
-        verify(api).saveItem(any(FederatedCacheNodeDocument.class));
+        verify(api).createItem(any(FederatedCacheNodeDocument.class));
     }
 
     @Test

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.catalog;
 
 import org.eclipse.edc.catalog.spi.CachedAsset;
@@ -8,7 +22,6 @@ import org.eclipse.edc.catalog.spi.FederatedCacheNodeDirectory;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
-import org.eclipse.edc.spi.message.MessageContext;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +51,6 @@ import static org.eclipse.edc.catalog.TestFunctions.insertSingle;
 import static org.eclipse.edc.catalog.TestFunctions.queryCatalogApi;
 import static org.eclipse.edc.catalog.TestFunctions.randomCatalog;
 import static org.eclipse.edc.catalog.matchers.CatalogRequestMatcher.sentTo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -71,7 +83,7 @@ public class CatalogRuntimeComponentTest {
         // prepare node directory
         insertSingle(directory);
         // intercept request egress
-        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class)))
                 .thenReturn(emptyCatalog());
 
         await().pollDelay(ofSeconds(1))
@@ -88,7 +100,7 @@ public class CatalogRuntimeComponentTest {
         // prepare node directory
         insertSingle(directory);
         // intercept request egress
-        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class)))
                 .thenReturn(randomCatalog(5))
                 .thenReturn(emptyCatalog()); // this is important, otherwise there is an endless loop!
 
@@ -104,7 +116,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
 
         // intercept request egress
-        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class)))
                 .thenReturn(randomCatalog(100))
                 .thenReturn(randomCatalog(100))
                 .thenReturn(randomCatalog(50))
@@ -114,7 +126,7 @@ public class CatalogRuntimeComponentTest {
                 .atMost(TEST_TIMEOUT)
                 .untilAsserted(() -> assertThat(queryCatalogApi()).hasSize(250));
 
-        verify(dispatcher, atLeast(4)).send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class));
+        verify(dispatcher, atLeast(4)).send(eq(Catalog.class), isA(CatalogRequest.class));
     }
 
     @Test
@@ -124,7 +136,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
 
         // intercept request egress
-        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class)))
                 .thenReturn(completedFuture(catalogBuilder().contractOffers(new ArrayList<>(List.of(
                         createOffer("offer1"), createOffer("offer2"), createOffer("offer3")
                 ))).build()))
@@ -137,7 +149,7 @@ public class CatalogRuntimeComponentTest {
         await().pollDelay(ofSeconds(1))
                 .atMost(TEST_TIMEOUT)
                 .untilAsserted(() -> {
-                    verify(dispatcher, atLeast(5)).send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class));
+                    verify(dispatcher, atLeast(5)).send(eq(Catalog.class), isA(CatalogRequest.class));
                     assertThat(queryCatalogApi()).hasSize(2)
                             .noneMatch(co -> co.getId().equals("offer3"));
                 });
@@ -151,7 +163,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
 
         // intercept request egress
-        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class)))
                 .thenReturn(completedFuture(catalogBuilder().contractOffers(new ArrayList<>(List.of(
                         createOffer("offer1"), createOffer("offer2"), createOffer("offer3")
                 ))).build()))
@@ -164,7 +176,7 @@ public class CatalogRuntimeComponentTest {
         await().pollDelay(ofSeconds(1))
                 .atMost(TEST_TIMEOUT)
                 .untilAsserted(() -> {
-                    verify(dispatcher, atLeast(4)).send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class));
+                    verify(dispatcher, atLeast(4)).send(eq(Catalog.class), isA(CatalogRequest.class));
                     assertThat(queryCatalogApi()).hasSize(3);
                 });
 
@@ -177,7 +189,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
 
         // intercept request egress
-        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class)))
                 .thenReturn(completedFuture(catalogBuilder().contractOffers(new ArrayList<>(List.of(
                         createOffer("offer1"), createOffer("offer2"), createOffer("offer3")
                 ))).build()))
@@ -193,7 +205,7 @@ public class CatalogRuntimeComponentTest {
                     var list = queryCatalogApi();
                     assertThat(list).hasSize(5)
                             .allSatisfy(co -> assertThat(Integer.parseInt(co.getId().replace("offer", ""))).isIn(1, 2, 3, 4, 5));
-                    verify(dispatcher, atLeast(4)).send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class));
+                    verify(dispatcher, atLeast(4)).send(eq(Catalog.class), isA(CatalogRequest.class));
                 });
 
     }
@@ -204,7 +216,7 @@ public class CatalogRuntimeComponentTest {
         // prepare node directory
         insertSingle(directory);
         // intercept request egress
-        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), isA(CatalogRequest.class)))
                 .thenReturn(randomCatalog(5))
                 .thenReturn(emptyCatalog()); // this is important, otherwise there is an endless loop!
 
@@ -234,7 +246,7 @@ public class CatalogRuntimeComponentTest {
 
                     var numAssets = rnd.nextInt(50);
 
-                    when(dispatcher.send(eq(Catalog.class), argThat(sentTo(nodeUrl + "/api/v1/ids/data")), any(MessageContext.class)))
+                    when(dispatcher.send(eq(Catalog.class), argThat(sentTo(nodeUrl + "/api/v1/ids/data"))))
                             .thenReturn(randomCatalog(numAssets))
                             .thenReturn(emptyCatalog());
                     numTotalAssets.addAndGet(numAssets);
@@ -255,11 +267,11 @@ public class CatalogRuntimeComponentTest {
         directory.insert(node1);
         directory.insert(node2);
 
-        when(dispatcher.send(eq(Catalog.class), argThat(sentTo("http://test-node1.com/api/v1/ids/data")), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), argThat(sentTo("http://test-node1.com/api/v1/ids/data"))))
                 .thenReturn(catalogOf(createOffer("offer1"), createOffer("offer2"), createOffer("offer3")))
                 .thenReturn(emptyCatalog());
 
-        when(dispatcher.send(eq(Catalog.class), argThat(sentTo("http://test-node2.com/api/v1/ids/data")), any(MessageContext.class)))
+        when(dispatcher.send(eq(Catalog.class), argThat(sentTo("http://test-node2.com/api/v1/ids/data"))))
                 .thenReturn(catalogOf(createOffer("offer14"), createOffer("offer32"), /*this one is conflicting:*/createOffer("offer3")))
                 .thenReturn(emptyCatalog());
 

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.catalog;
 
 import io.restassured.common.mapper.TypeRef;

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/instrumentation/MockInjectionExtension.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/instrumentation/MockInjectionExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.catalog.instrumentation;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/matchers/CatalogRequestMatcher.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/matchers/CatalogRequestMatcher.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.catalog.matchers;
 
 import org.eclipse.edc.catalog.spi.CatalogRequest;

--- a/system-tests/end2end-test/catalog-runtime/src/main/java/org/eclipse/edc/catalog/node/directory/filesystem/CatalogExtension.java
+++ b/system-tests/end2end-test/catalog-runtime/src/main/java/org/eclipse/edc/catalog/node/directory/filesystem/CatalogExtension.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.catalog.node.directory.filesystem;
 
 import org.eclipse.edc.catalog.spi.FederatedCacheNodeDirectory;

--- a/system-tests/end2end-test/catalog-runtime/src/main/java/org/eclipse/edc/catalog/node/directory/filesystem/FileBasedNodeDirectory.java
+++ b/system-tests/end2end-test/catalog-runtime/src/main/java/org/eclipse/edc/catalog/node/directory/filesystem/FileBasedNodeDirectory.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.catalog.node.directory.filesystem;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.end2end;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/ManagementApiClient.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/ManagementApiClient.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.end2end;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.end2end;
 
 import org.eclipse.edc.connector.api.management.asset.model.AssetCreationRequestDto;


### PR DESCRIPTION
## What this PR changes/adds

Adapts the code to fit to the latest changes in the upstream:
- update usage of the `CosmosDbApi`
- remove usages of `MessageContext`

## Why it does that

fix compiler errors

## Further notes

.

## Linked Issue(s)

Closes #
