### PR TITLE
build: publish version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,8 @@
 
 plugins {
     `java-library`
+    `maven-publish`
+    `version-catalog`
 }
 
 val javaVersion: String by project
@@ -25,9 +27,6 @@ val annotationProcessorVersion: String by project
 val metaModelVersion: String by project
 
 buildscript {
-    repositories {
-        mavenLocal()
-    }
     dependencies {
         val edcGradlePluginsVersion: String by project
         classpath("org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin:${edcGradlePluginsVersion}")
@@ -70,4 +69,13 @@ allprojects {
         configDirectory.set(rootProject.file("resources"))
     }
 
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("federated-catalog-version-catalog") {
+            from(components["versionCatalog"])
+            artifactId = "federated-catalog-versions"
+        }
+    }
 }

--- a/core/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog-core/build.gradle.kts
@@ -18,23 +18,18 @@ plugins {
 }
 
 dependencies {
-    api(edc.spi.core)
-    api(edc.spi.web)
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.web)
     api(project(":spi:federated-catalog-spi"))
 
-    implementation(edc.util)
-    implementation(edc.core.connector)
-
-    implementation(libs.okhttp)
-
-    implementation(libs.jakarta.rsApi)
-    implementation(libs.failsafe.core)
+    implementation(libs.edc.util)
+    implementation(libs.edc.core.connector)
 
     // required for integration test
-    testImplementation(edc.junit)
-    testImplementation(edc.ext.http)
-    testImplementation(edc.spi.ids)
-    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.ext.http)
+    testImplementation(libs.edc.spi.ids)
+    testImplementation(root.awaitility)
 }
 
 edcBuild {

--- a/extensions/api/federated-catalog-api/build.gradle.kts
+++ b/extensions/api/federated-catalog-api/build.gradle.kts
@@ -18,19 +18,18 @@ plugins {
 }
 
 dependencies {
-    api(edc.spi.core)
-    implementation(edc.spi.web)
+    api(libs.edc.spi.core)
+    implementation(libs.edc.spi.web)
     api(project(":spi:federated-catalog-spi"))
 
-    runtimeOnly(edc.core.connector)
-    implementation(libs.jakarta.rsApi)
-    implementation(edc.api.management.config)
+    runtimeOnly(libs.edc.core.connector)
+    implementation(libs.edc.api.management.config)
 
     // required for integration test
     testImplementation(testFixtures(project(":core:federated-catalog-core"))) // provides the TestUtil
-    testImplementation(edc.junit)
-    testImplementation(edc.ext.http)
-    testImplementation(libs.restAssured)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.ext.http)
+    testImplementation(root.restAssured)
 }
 
 edcBuild {

--- a/extensions/store/fcc-node-directory-cosmos/build.gradle.kts
+++ b/extensions/store/fcc-node-directory-cosmos/build.gradle.kts
@@ -18,10 +18,10 @@ plugins {
 
 dependencies {
     api(project(":spi:federated-catalog-spi"))
-    api(edc.ext.azure.cosmos.core)
+    api(libs.edc.ext.azure.cosmos.core)
 
-    implementation(libs.azure.cosmos)
-    implementation(libs.failsafe.core)
+    implementation(root.azure.cosmos)
+    implementation(root.failsafe.core)
 
-    testImplementation(testFixtures(edc.ext.azure.test))
+    testImplementation(testFixtures(libs.edc.ext.azure.test))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ edcGradlePluginsVersion=0.0.1-SNAPSHOT
 metaModelVersion=0.0.1-SNAPSHOT
 
 # used for publishing artifacts and plugins
-fccScmConnection=scm:git:git@github.com:eclipse-dataspaceconnector/FederatedCatalog.git
-fccWebsiteUrl=https://github.com/eclipse-dataspaceconnector/FederatedCatalog.git
-fccScmUrl=https://github.com/eclipse-dataspaceconnector/FederatedCatalog.git
+fccScmConnection=scm:git:git@github.com:eclipse-edc/FederatedCatalog.git
+fccWebsiteUrl=https://github.com/eclipse-edc/FederatedCatalog.git
+fccScmUrl=https://github.com/eclipse-edc/FederatedCatalog.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,39 @@
+[metadata]
+format.version = "1.1"
+
+[versions]
+edc = "0.0.1-SNAPSHOT"
+
+[libraries]
+edc-api-management = { module = "org.eclipse.edc:management-api", version.ref = "edc" }
+edc-api-management-config = { module = "org.eclipse.edc:management-api-configuration", version.ref = "edc" }
+edc-api-observability = { module = "org.eclipse.edc:api-observability", version.ref = "edc" }
+edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
+edc-config-filesystem = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
+edc-core-connector = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
+edc-core-controlplane = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
+edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
+edc-core-jetty = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
+edc-dpf-framework = { module = "org.eclipse.edc:data-plane-framework", version.ref = "edc" }
+edc-dpf-selector-client = { module = "org.eclipse.edc:data-plane-selector-client", version.ref = "edc" }
+edc-dpf-selector-core = { module = "org.eclipse.edc:data-plane-selector-core", version.ref = "edc" }
+edc-dpf-selector-spi = { module = "org.eclipse.edc:data-plane-selector-spi", version.ref = "edc" }
+edc-dpf-transferclient = { module = "org.eclipse.edc:data-plane-transfer-client", version.ref = "edc" }
+edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", version.ref = "edc" }
+edc-ext-azure-test = { module = "org.eclipse.edc:azure-test", version.ref = "edc" }
+edc-ext-http = { module = "org.eclipse.edc:http", version.ref = "edc" }
+edc-iam-mock = { module = "org.eclipse.edc:iam-mock", version.ref = "edc" }
+edc-ids = { module = "org.eclipse.edc:ids", version.ref = "edc" }
+edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
+edc-spi-catalog = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
+edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
+edc-spi-ids = { module = "org.eclipse.edc:ids-spi", version.ref = "edc" }
+edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
+edc-util = { module = "org.eclipse.edc:util", version.ref = "edc" }
+
+[bundles]
+edc-connector = [ "edc-boot", "edc-core-connector", "edc-core-jersey", "edc-core-controlplane", "edc-api-observability" ]
+edc-dpf = [ "edc-dpf-transferclient", "edc-dpf-selector-client", "edc-dpf-selector-spi", "edc-dpf-selector-core", "edc-dpf-framework" ]
+
+[plugins]
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.0.0" }

--- a/launchers/build.gradle.kts
+++ b/launchers/build.gradle.kts
@@ -15,13 +15,13 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.0.0"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {
     runtimeOnly(project(":core:federated-catalog-core"))
     runtimeOnly(project(":extensions:api:federated-catalog-api"))
-    runtimeOnly(edc.bundles.connector)
+    runtimeOnly(libs.bundles.edc.connector)
 }
 
 application {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,6 @@ include(":system-tests:end2end-test:connector-runtime")
 include(":system-tests:end2end-test:catalog-runtime")
 include(":system-tests:end2end-test:e2e-junit-runner")
 
-
 // this is needed to have access to snapshot builds of plugins
 pluginManagement {
     repositories {
@@ -25,62 +24,16 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }
         mavenCentral()
-        mavenLocal()
     }
+
     versionCatalogs {
-        create("libs") {
+        create("root") {
             from("org.eclipse.edc:edc-versions:0.0.1-SNAPSHOT")
-        }
-        // create version catalog for all EDC modules
-        create("edc") {
-            version("edc", "0.0.1-SNAPSHOT")
-            library("spi-catalog", "org.eclipse.edc", "catalog-spi").versionRef("edc")
-            library("spi-core", "org.eclipse.edc", "core-spi").versionRef("edc")
-            library("spi-web", "org.eclipse.edc", "web-spi").versionRef("edc")
-            library("util", "org.eclipse.edc", "util").versionRef("edc")
-            library("boot", "org.eclipse.edc", "boot").versionRef("edc")
-            library("config-filesystem", "org.eclipse.edc", "configuration-filesystem").versionRef("edc")
-            library("core-controlplane", "org.eclipse.edc", "control-plane-core").versionRef("edc")
-            library("core-connector", "org.eclipse.edc", "connector-core").versionRef("edc")
-            library("core-jetty", "org.eclipse.edc", "jetty-core").versionRef("edc")
-            library("core-jersey", "org.eclipse.edc", "jersey-core").versionRef("edc")
-            library("junit", "org.eclipse.edc", "junit").versionRef("edc")
-            library("api-management-config", "org.eclipse.edc", "management-api-configuration").versionRef("edc")
-            library("api-management", "org.eclipse.edc", "management-api").versionRef("edc")
-            library("api-observability", "org.eclipse.edc", "api-observability").versionRef("edc")
-            library("ext-http", "org.eclipse.edc", "http").versionRef("edc")
-            library("spi-ids", "org.eclipse.edc", "ids-spi").versionRef("edc")
-            library("ids", "org.eclipse.edc", "ids").versionRef("edc")
-            library("iam-mock", "org.eclipse.edc", "iam-mock").versionRef("edc")
-            library("ext-azure-cosmos-core", "org.eclipse.edc", "azure-cosmos-core").versionRef("edc")
-            library("ext-azure-test", "org.eclipse.edc", "azure-test").versionRef("edc")
-
-            // DPF modules
-            library("dpf-transferclient", "org.eclipse.edc", "data-plane-transfer-client").versionRef("edc")
-            library("dpf-selector-client", "org.eclipse.edc", "data-plane-selector-client").versionRef("edc")
-            library("dpf-selector-spi", "org.eclipse.edc", "data-plane-selector-spi").versionRef("edc")
-            library("dpf-selector-core", "org.eclipse.edc", "data-plane-selector-core").versionRef("edc")
-            library("dpf-framework", "org.eclipse.edc", "data-plane-framework").versionRef("edc")
-
-            bundle(
-                "connector",
-                listOf("boot", "core-connector", "core-jersey", "core-controlplane", "api-observability")
-            )
-
-            bundle(
-                "dpf",
-                listOf(
-                    "dpf-transferclient",
-                    "dpf-selector-client",
-                    "dpf-selector-spi",
-                    "dpf-selector-core",
-                    "dpf-framework"
-                )
-            )
         }
     }
 }

--- a/spi/federated-catalog-spi/build.gradle.kts
+++ b/spi/federated-catalog-spi/build.gradle.kts
@@ -17,6 +17,6 @@ plugins {
 }
 
 dependencies {
-    api(edc.spi.catalog)
-    api(edc.spi.core)
+    api(libs.edc.spi.catalog)
+    api(libs.edc.spi.core)
 }

--- a/system-tests/component-tests/build.gradle.kts
+++ b/system-tests/component-tests/build.gradle.kts
@@ -19,13 +19,12 @@ plugins {
 dependencies {
     implementation(project(":core:federated-catalog-core"))
     implementation(project(":extensions:api:federated-catalog-api"))
-    runtimeOnly(edc.bundles.connector)
+    runtimeOnly(libs.bundles.edc.connector)
 
-    testImplementation(edc.junit)
-    testImplementation(libs.okhttp)
-    testImplementation(libs.restAssured)
-    testImplementation(libs.bundles.jupiter)
-    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(root.restAssured)
+    testImplementation(root.bundles.jupiter)
+    testImplementation(root.awaitility)
 }
 
 edcBuild {

--- a/system-tests/end2end-test/catalog-runtime/build.gradle.kts
+++ b/system-tests/end2end-test/catalog-runtime/build.gradle.kts
@@ -15,19 +15,19 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.0.0"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {
     runtimeOnly(project(":core:federated-catalog-core"))
     runtimeOnly(project(":extensions:api:federated-catalog-api"))
     implementation(project(":spi:federated-catalog-spi"))
-    implementation(edc.util)
-    runtimeOnly(edc.bundles.connector)
+    implementation(libs.edc.util)
+    runtimeOnly(libs.bundles.edc.connector)
 
     // IDS stuff
-    runtimeOnly(edc.ids)
-    runtimeOnly(edc.iam.mock)
+    runtimeOnly(libs.edc.ids)
+    runtimeOnly(libs.edc.iam.mock)
 }
 
 application {

--- a/system-tests/end2end-test/connector-runtime/build.gradle.kts
+++ b/system-tests/end2end-test/connector-runtime/build.gradle.kts
@@ -15,23 +15,23 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.0.0"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {
 
-    runtimeOnly(edc.core.controlplane)
-    runtimeOnly(edc.api.observability)
-    runtimeOnly(edc.api.management)
-    runtimeOnly(edc.config.filesystem)
-    runtimeOnly(edc.ext.http)
+    runtimeOnly(libs.edc.core.controlplane)
+    runtimeOnly(libs.edc.api.observability)
+    runtimeOnly(libs.edc.api.management)
+    runtimeOnly(libs.edc.config.filesystem)
+    runtimeOnly(libs.edc.ext.http)
 
     // IDS
-    runtimeOnly(edc.ids)
-    runtimeOnly(edc.iam.mock)
+    runtimeOnly(libs.edc.ids)
+    runtimeOnly(libs.edc.iam.mock)
 
     // Embedded DPF
-    runtimeOnly(edc.bundles.dpf)
+    runtimeOnly(libs.bundles.edc.dpf)
 }
 
 application {

--- a/system-tests/end2end-test/docker-compose.yml
+++ b/system-tests/end2end-test/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 0
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 2
       EDC_CATALOG_CACHE_PARTITION_NUM_CRAWLERS: 5
+      EDC_IDS_ID: urn:connector:fcc
       EDC_WEB_REST_CORS_ENABLED: "true"
       EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
       FCC_DIRECTORY_FILE: /resources/nodes-dc.json
@@ -33,6 +34,7 @@ services:
     environment:
       IDS_WEBHOOK_ADDRESS: http://connector1:8282
       EDC_CONNECTOR_NAME: connector1
+      EDC_IDS_ID: urn:connector:1
       EDC_WEB_REST_CORS_ENABLED: "true"
       EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
     ports:

--- a/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
+++ b/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
@@ -18,11 +18,9 @@ plugins {
 
 dependencies {
     testImplementation(project(":spi:federated-catalog-spi"))
-    testImplementation(edc.api.management)
-    testImplementation(libs.awaitility)
-    testImplementation(libs.okhttp)
-    testImplementation(edc.junit)
-    testRuntimeOnly(libs.jackson.datatypeJsr310)
+    testImplementation(libs.edc.api.management)
+    testImplementation(root.awaitility)
+    testImplementation(libs.edc.junit)
 }
 
 edcBuild {


### PR DESCRIPTION
## What this PR changes/adds

- Move the version catalog to the default `gradle/libs.versions.toml`
- Create publication of the catalog called `federated-catalog-versions`
- import the `GradlePlugins` catalog as `root` (no better terms came to mind, `edc` would be too redundant, `super` cannot be used...)

## Why it does that

version catalog refactoring

## Further notes

- ~~some versions as `mockito`, `jackson`... are needed because `DefaultDependencyConvention` (in `GradlePlugins`) requires them, I'd say that this need to change (will be fixed by https://github.com/eclipse-edc/GradlePlugins/pull/127)~~ fix merged

## Linked Issue(s)

Closes #90 
