### PR TITLE
feat(protocol): add query adapter for the new DSP

### DIFF
--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.catalog.cache;
 
 import org.eclipse.edc.catalog.cache.crawler.NodeQueryAdapterRegistryImpl;
+import org.eclipse.edc.catalog.cache.query.DspNodeQueryAdapter;
 import org.eclipse.edc.catalog.cache.query.IdsMultipartNodeQueryAdapter;
 import org.eclipse.edc.catalog.spi.CacheConfiguration;
 import org.eclipse.edc.catalog.spi.Catalog;
@@ -35,6 +36,7 @@ import org.eclipse.edc.spi.system.health.HealthCheckResult;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
 
 import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.catalog.cache.query.IdsMultipartNodeQueryAdapter.IDS_MULTIPART_PROTOCOL;
 
 @Extension(value = FederatedCatalogCacheExtension.NAME)
 public class FederatedCatalogCacheExtension implements ServiceExtension {
@@ -102,8 +104,9 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
     public NodeQueryAdapterRegistry createNodeQueryAdapterRegistry(ServiceExtensionContext context) {
         if (nodeQueryAdapterRegistry == null) {
             nodeQueryAdapterRegistry = new NodeQueryAdapterRegistryImpl();
-            // catalog queries via IDS multipart are supported by default
-            nodeQueryAdapterRegistry.register("ids-multipart", new IdsMultipartNodeQueryAdapter(context.getConnectorId(), dispatcherRegistry, context.getMonitor()));
+            // catalog queries via IDS multipart and DSP are supported by default
+            nodeQueryAdapterRegistry.register(IDS_MULTIPART_PROTOCOL, new IdsMultipartNodeQueryAdapter(context.getConnectorId(), dispatcherRegistry, context.getMonitor()));
+            nodeQueryAdapterRegistry.register(DspNodeQueryAdapter.DATASPACE_PROTOCOL, new DspNodeQueryAdapter(dispatcherRegistry, context.getMonitor()));
         }
         return nodeQueryAdapterRegistry;
     }

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/BatchedRequestFetcher.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/BatchedRequestFetcher.java
@@ -53,6 +53,7 @@ public class BatchedRequestFetcher {
                 .build();
     }
 
+
     /**
      * Gets all contract offers. Requests are split in digestible chunks to match {@code batchSize} until no more offers
      * can be obtained.
@@ -63,6 +64,7 @@ public class BatchedRequestFetcher {
      * @return A list of {@link ContractOffer} objects
      */
     public @NotNull CompletableFuture<Catalog> fetch(CatalogRequestMessage catalogRequest, int from, int batchSize) {
+
         var range = new Range(from, from + batchSize);
         var rq = catalogRequest.toBuilder().querySpec(QuerySpec.Builder.newInstance().range(range).build()).build();
 
@@ -78,6 +80,10 @@ public class BatchedRequestFetcher {
                         return CompletableFuture.completedFuture(catalog);
                     }
                 });
+    }
+
+    private QuerySpec forRange(Range range) {
+        return QuerySpec.Builder.newInstance().range(range).build();
     }
 
     private Catalog concat(Catalog target, Catalog source) {

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspNodeQueryAdapter.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspNodeQueryAdapter.java
@@ -1,0 +1,35 @@
+package org.eclipse.edc.catalog.cache.query;
+
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.catalog.spi.NodeQueryAdapter;
+import org.eclipse.edc.catalog.spi.model.UpdateRequest;
+import org.eclipse.edc.catalog.spi.model.UpdateResponse;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+
+import java.util.concurrent.CompletableFuture;
+
+public class DspNodeQueryAdapter implements NodeQueryAdapter {
+    public static final String DATASPACE_PROTOCOL = "dataspace-protocol-http";
+    private static final int INITIAL_OFFSET = 0;
+    private static final int BATCH_SIZE = 100;
+    private final BatchedRequestFetcher fetcher;
+
+    public DspNodeQueryAdapter(RemoteMessageDispatcherRegistry dispatcherRegistry, Monitor monitor) {
+
+        fetcher = new BatchedRequestFetcher(dispatcherRegistry, monitor);
+    }
+
+    @Override
+    public CompletableFuture<UpdateResponse> sendRequest(UpdateRequest request) {
+
+        var dspUrl = request.getNodeUrl();
+        var catalogRequest = CatalogRequestMessage.Builder.newInstance()
+                .protocol(DATASPACE_PROTOCOL)
+                .counterPartyAddress(dspUrl)
+                .build();
+        var catalogFuture = fetcher.fetch(catalogRequest, INITIAL_OFFSET, BATCH_SIZE);
+
+        return catalogFuture.thenApply(catalog -> new UpdateResponse(dspUrl, catalog));
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/IdsMultipartNodeQueryAdapter.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 
 import java.util.concurrent.CompletableFuture;
 
+@Deprecated(forRemoval = true, since = "milestone9")
 public class IdsMultipartNodeQueryAdapter implements NodeQueryAdapter {
     public static final String IDS_MULTIPART_PROTOCOL = "ids-multipart";
     private final String connectorId;

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCacheStoreTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCacheStoreTest.java
@@ -26,8 +26,6 @@ import org.eclipse.edc.util.concurrency.LockManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -51,8 +49,6 @@ class InMemoryFederatedCacheStoreTest {
                 .id(id)
                 .assetId(asset.getId())
                 .policy(Policy.Builder.newInstance().build())
-                .contractStart(ZonedDateTime.now())
-                .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                 .build();
     }
 

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/BatchedRequestFetcherTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/BatchedRequestFetcherTest.java
@@ -25,8 +25,6 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -95,8 +93,6 @@ class BatchedRequestFetcherTest {
                         .id("id" + i)
                         .policy(Policy.Builder.newInstance().build())
                         .assetId("asset" + i)
-                        .contractStart(ZonedDateTime.now())
-                        .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                         .build())
                 .collect(Collectors.toList());
 

--- a/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -21,8 +21,6 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -41,8 +39,6 @@ public class TestUtil {
                 .id(id)
                 .assetId(id)
                 .policy(Policy.Builder.newInstance().build())
-                .contractStart(ZonedDateTime.now())
-                .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                 .build();
     }
 

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
@@ -24,8 +24,6 @@ import org.eclipse.edc.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -78,8 +76,6 @@ public class TestFunctions {
                 .id(id)
                 .assetId(id)
                 .policy(Policy.Builder.newInstance().build())
-                .contractStart(ZonedDateTime.now())
-                .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                 .build();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a query adapter for the DSP protocol.

## Why it does that

Compliance with the new DSP protocol

## Further notes

- The `FederatedCacheNode.targetUrl` **MUST** contain the full path of the DSP endpoint
- The `FederatedCacheNode.supportedProtocols` **MUST ONLY** contain `"dataspace-protocol-http"`, please remove the old `ids-multipart`


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
