### PR TITLE
build: add action to bump the snapshot version

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -1,0 +1,42 @@
+name: "Bump version in gradle.properties"
+description: "Increments the patch version of the version found in gradle.properties, appends -SNAPSHOT"
+inputs:
+  target_branch:
+    default: 'main'
+    description: "Branch on which the version bump is to be done."
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: read version from gradle.properties
+      shell: bash
+      run: |
+        # Prepare git env
+        git config user.name "eclipse-edc-bot"
+        git config user.email "edc-bot@eclipse.org"
+
+        # checkout target
+        git fetch origin
+        git checkout ${{ inputs.target_branch }}
+
+        # determine current version
+        oldVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+
+        # read the major, minor, and patch components, consume -SNAPSHOT
+        IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"$oldVersion"
+
+        # construct the new version
+        newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
+
+        # replace every occurrence of =$oldVersion with =$newVersion
+        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i 's/$oldVersion/$newVersion/g'
+
+        echo "Bumped the version from $oldVersion to $newVersion"
+
+        # Commit and push to the desired branch, defaults to 'main'
+        git add .
+        git commit --message "Bump version from $oldVersion to $newVersion [skip ci]"
+
+        git push origin ${{ inputs.target_branch }}

--- a/.github/workflows/release-fcc.yml
+++ b/.github/workflows/release-fcc.yml
@@ -43,7 +43,7 @@ jobs:
 
   Github-Release:
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
-    if:  ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
     needs:
       - Prepare-Release
     runs-on: ubuntu-latest
@@ -60,3 +60,15 @@ jobs:
           tag: "v${{ env.EDC_VERSION }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           removeArtifacts: true
+
+  Bump-Version:
+    name: 'Update release version'
+    # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
+    needs: [ Prepare-Release, Github-Release ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bump-version
+        with:
+          target_branch: "main"

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
@@ -24,7 +24,7 @@ import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNew
 import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_DATA_ADDRESS;
 import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_ACCESSPOLICY_ID;
 import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_CONTRACTPOLICY_ID;
-import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_CRITERIA;
+import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_SELECTOR_EXPRESSION;
 import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -58,7 +58,7 @@ public class TestFunctions {
                 .add(ID, id)
                 .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, accessPolicyId)
                 .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, contractPolicyId)
-                .add(CONTRACT_DEFINITION_CRITERIA, createCriterionBuilder(assetId).build())
+                .add(CONTRACT_DEFINITION_SELECTOR_EXPRESSION, createCriterionBuilder(assetId).build())
                 .build();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a job to automatically bump the version after a GH release

## Why it does that

updated the version automatically

## Further notes

- fixed a compile error due to the renaming of a constant

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

