### PR TITLE
chore: update snapshot version to 0.1.0-SNAPSHOT

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -31,7 +31,7 @@ runs:
         newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
 
         # replace every occurrence of =$oldVersion with =$newVersion
-        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i 's/$oldVersion/$newVersion/g'
+        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$oldVersion/$newVersion/g"
 
         echo "Bumped the version from $oldVersion to $newVersion"
 

--- a/core/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog-core/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     // required for integration test
     testImplementation(libs.edc.junit)
     testImplementation(libs.edc.ext.http)
-    testImplementation(libs.edc.spi.ids)
     testImplementation(libs.awaitility)
 }
 

--- a/docs/legal/generateThirdPartyReport.sh
+++ b/docs/legal/generateThirdPartyReport.sh
@@ -7,7 +7,7 @@
 # The Eclipse Dash Licenses tool was executed and resulted in an file (e.g., NOTICES)
 # listing all dependencies of the project.
 # To process the dependencies of a specific module, execute the following command:
-#   gradle dependencies | grep -Poh "(?<=\s)[\w\.-]+:[\w\.-]+:[^:\s]+" | sort | uniq | java -jar /path/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar - -summary NOTICES
+#   gradle dependencies | grep -Poh "(?<=\s)[\w\.-]+:[\w\.-]+:[^:\s]+" | sort | uniq | java -jar /path/org.eclipse.dash.licenses-<VERSION>.jar - -summary NOTICES
 #
 # Comments:
 # Gradle doesn't support listing all dependencies of a multi-module project out of the box.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 group=org.eclipse.edc
-version=0.0.1-SNAPSHOT
+version=0.1.0-SNAPSHOT
 
 # configure the build:
-annotationProcessorVersion=0.0.1-SNAPSHOT
-edcGradlePluginsVersion=0.0.1-SNAPSHOT
-metaModelVersion=0.0.1-SNAPSHOT
+annotationProcessorVersion=0.1.0-SNAPSHOT
+edcGradlePluginsVersion=0.1.0-SNAPSHOT
+metaModelVersion=0.1.0-SNAPSHOT
 
 # used for publishing artifacts and plugins
 fccScmConnection=scm:git:git@github.com:eclipse-edc/FederatedCatalog.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,6 @@ edc-ids = { module = "org.eclipse.edc:ids", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-spi-catalog = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
-edc-spi-ids = { module = "org.eclipse.edc:ids-spi", version.ref = "edc" }
 edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-jsonld = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" }
 edc-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ edc-dpf-framework = { module = "org.eclipse.edc:data-plane-framework", version.r
 edc-dpf-selector-client = { module = "org.eclipse.edc:data-plane-selector-client", version.ref = "edc" }
 edc-dpf-selector-core = { module = "org.eclipse.edc:data-plane-selector-core", version.ref = "edc" }
 edc-dpf-selector-spi = { module = "org.eclipse.edc:data-plane-selector-spi", version.ref = "edc" }
-edc-dpf-transferclient = { module = "org.eclipse.edc:data-plane-transfer-client", version.ref = "edc" }
 edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", version.ref = "edc" }
 edc-ext-azure-test = { module = "org.eclipse.edc:azure-test", version.ref = "edc" }
 edc-ext-http = { module = "org.eclipse.edc:http", version.ref = "edc" }
@@ -47,7 +46,7 @@ edc-dsp-all = { module = "org.eclipse.edc:dsp", version.ref = "edc" }
 
 [bundles]
 edc-connector = ["edc-boot", "edc-core-connector", "edc-core-jersey", "edc-api-observability"]
-edc-dpf = ["edc-dpf-transferclient", "edc-dpf-selector-client", "edc-dpf-selector-spi", "edc-dpf-selector-core", "edc-dpf-framework"]
+edc-dpf = ["edc-dpf-selector-client", "edc-dpf-selector-spi", "edc-dpf-selector-core", "edc-dpf-framework"]
 
 [plugins]
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 awaitility = "4.2.0"
-edc = "0.0.1-SNAPSHOT"
+edc = "0.1.0-SNAPSHOT"
 failsafe = "3.3.1"
 restAssured = "5.3.0"
 

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
@@ -23,8 +23,8 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_ASSET;
 import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_DATA_ADDRESS;
 import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_ACCESSPOLICY_ID;
+import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_ASSETS_SELECTOR;
 import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_CONTRACTPOLICY_ID;
-import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_SELECTOR_EXPRESSION;
 import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -58,7 +58,7 @@ public class TestFunctions {
                 .add(ID, id)
                 .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, accessPolicyId)
                 .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, contractPolicyId)
-                .add(CONTRACT_DEFINITION_SELECTOR_EXPRESSION, createCriterionBuilder(assetId).build())
+                .add(CONTRACT_DEFINITION_ASSETS_SELECTOR, createCriterionBuilder(assetId).build())
                 .build();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Update snapshot version to `0.1.0-SNAPSHOT`

## Why it does that

Our next release version will be `0.1.0`, thus the next snapshot will be `0.1.1-SNAPSHOT` and the automatic version bump mechanism currently only bumps the `patch` version.

## Further notes

- depends on https://github.com/eclipse-edc/GradlePlugins/pull/162
- depends on https://github.com/eclipse-edc/Connector/pull/3108


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
