### PR TITLE
fix: Use EDC namespace for originator property

### DIFF
--- a/extensions/store/fcc-node-directory-cosmos/src/main/java/org/eclipse/edc/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryExtension.java
+++ b/extensions/store/fcc-node-directory-cosmos/src/main/java/org/eclipse/edc/catalog/node/directory/azure/CosmosFederatedCacheNodeDirectoryExtension.java
@@ -45,6 +45,9 @@ public class CosmosFederatedCacheNodeDirectoryExtension implements ServiceExtens
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private RetryPolicy<Object> retryPolicy;
+
     @Override
     public String name() {
         return NAME;
@@ -55,13 +58,13 @@ public class CosmosFederatedCacheNodeDirectoryExtension implements ServiceExtens
         var configuration = new FederatedCacheNodeDirectoryCosmosConfig(context);
 
         var cosmosDbApi = new CosmosDbApiImpl(configuration, clientProvider.createClient(vault, configuration));
-        FederatedCacheNodeDirectory directory = new CosmosFederatedCacheNodeDirectory(cosmosDbApi, configuration.getPartitionKey(), typeManager, context.getService(RetryPolicy.class));
+
+        var directory = new CosmosFederatedCacheNodeDirectory(cosmosDbApi, configuration.getPartitionKey(), typeManager, retryPolicy);
         context.registerService(FederatedCacheNodeDirectory.class, directory);
 
         typeManager.registerTypes(FederatedCacheNodeDocument.class);
 
         context.getService(HealthCheckService.class).addReadinessProvider(() -> cosmosDbApi.get().forComponent(name()));
-
     }
 
 }

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogConstants.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogConstants.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.catalog.spi;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 public interface CatalogConstants {
-    String PROPERTY_ORIGINATOR = "asset:prop:originator";
+    String PROPERTY_ORIGINATOR = EDC_NAMESPACE + "originator";
     String DATASPACE_PROTOCOL = "dataspace-protocol-http";
 }


### PR DESCRIPTION
## What this PR changes/adds

Use EDC namespace for `originator` property

## Why it does that

Use proper namespace.
