### PR TITLE
fix: upgrade catalog-api to JSON-LD

### DIFF
--- a/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -15,6 +15,9 @@
 package org.eclipse.edc.catalog.test;
 
 import org.eclipse.edc.catalog.spi.Catalog;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Dataset;
+import org.eclipse.edc.catalog.spi.Distribution;
 import org.eclipse.edc.catalog.spi.FederatedCacheNode;
 import org.eclipse.edc.catalog.spi.WorkItem;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
@@ -43,9 +46,12 @@ public class TestUtil {
     }
 
     public static Catalog createCatalog(String id) {
+        var dataService = DataService.Builder.newInstance().build();
         return Catalog.Builder.newInstance()
                 .id(id)
                 .contractOffers(List.of(createOffer("test-offer")))
+                .dataServices(List.of(dataService))
+                .datasets(List.of(Dataset.Builder.newInstance().distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build()))
                 .properties(new HashMap<>())
                 .build();
     }

--- a/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApi.java
+++ b/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApi.java
@@ -21,11 +21,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.eclipse.edc.catalog.spi.Catalog;
+import jakarta.json.JsonArray;
 import org.eclipse.edc.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
-
-import java.util.List;
 
 @OpenAPIDefinition
 @Tag(name = "Federated Catalog")
@@ -38,5 +36,5 @@ public interface FederatedCatalogApi {
             }
 
     )
-    List<Catalog> getCachedCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery);
+    JsonArray getCachedCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery);
 }

--- a/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiController.java
+++ b/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiController.java
@@ -14,32 +14,38 @@
 
 package org.eclipse.edc.catalog.api.query;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.QueryEngine;
 import org.eclipse.edc.catalog.spi.QueryResponse;
 import org.eclipse.edc.catalog.spi.model.FederatedCatalogCacheQuery;
+import org.eclipse.edc.spi.result.AbstractResult;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
-import java.util.List;
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
 @Path("/federatedcatalog")
 public class FederatedCatalogApiController implements FederatedCatalogApi {
 
     private final QueryEngine queryEngine;
+    private final TypeTransformerRegistry transformerRegistry;
 
-    public FederatedCatalogApiController(QueryEngine queryEngine) {
+    public FederatedCatalogApiController(QueryEngine queryEngine, TypeTransformerRegistry transformerRegistry) {
         this.queryEngine = queryEngine;
+        this.transformerRegistry = transformerRegistry;
     }
 
     @Override
     @POST
-    public List<Catalog> getCachedCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery) {
+    public JsonArray getCachedCatalog(FederatedCatalogCacheQuery federatedCatalogCacheQuery) {
         var queryResponse = queryEngine.getCatalog(federatedCatalogCacheQuery);
         // query not possible
         if (queryResponse.getStatus() == QueryResponse.Status.NO_ADAPTER_FOUND) {
@@ -49,6 +55,10 @@ public class FederatedCatalogApiController implements FederatedCatalogApi {
             throw new QueryException(queryResponse.getErrors());
         }
 
-        return queryResponse.getCatalogs();
+        var catalogs = queryResponse.getCatalogs();
+        return catalogs.stream().map(c -> transformerRegistry.transform(c, JsonObject.class))
+                .filter(Result::succeeded)
+                .map(AbstractResult::getContent)
+                .collect(toJsonArray());
     }
 }

--- a/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogCacheQueryApiExtension.java
+++ b/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogCacheQueryApiExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.health.HealthCheckResult;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
 @Extension(value = FederatedCatalogCacheQueryApiExtension.NAME)
@@ -39,6 +40,9 @@ public class FederatedCatalogCacheQueryApiExtension implements ServiceExtension 
 
     @Inject
     private ManagementApiConfiguration config;
+    
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
 
     @Override
     public String name() {
@@ -47,7 +51,7 @@ public class FederatedCatalogCacheQueryApiExtension implements ServiceExtension 
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var catalogController = new FederatedCatalogApiController(queryEngine);
+        var catalogController = new FederatedCatalogApiController(queryEngine, transformerRegistry);
         webService.registerResource(config.getContextAlias(), catalogController);
 
         // contribute to the liveness probe

--- a/extensions/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
+++ b/extensions/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
@@ -17,12 +17,12 @@ package org.eclipse.edc.catalog.api.query;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.catalog.spi.CacheQueryAdapter;
 import org.eclipse.edc.catalog.spi.CacheQueryAdapterRegistry;
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.FederatedCacheStore;
 import org.eclipse.edc.catalog.spi.model.FederatedCatalogCacheQuery;
-import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.catalog.test.TestUtil.createCatalog;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
@@ -46,7 +45,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(EdcExtension.class)
 class FederatedCatalogApiControllerTest {
     private static final String BASE_PATH = "/api";
-    private static final TypeRef<List<Catalog>> CONTRACT_OFFER_LIST_TYPE = new TypeRef<>() {
+    private static final TypeRef<List<JsonObject>> CONTRACT_OFFER_LIST_TYPE = new TypeRef<>() {
     };
     private final int port = getFreePort();
 
@@ -93,7 +92,7 @@ class FederatedCatalogApiControllerTest {
                 .as(CONTRACT_OFFER_LIST_TYPE);
 
         // test
-        compareByAssetId(offers, entries);
+        assertThat(offers).hasSameSizeAs(entries);
     }
 
     @Test
@@ -112,11 +111,6 @@ class FederatedCatalogApiControllerTest {
 
     }
 
-    private void compareByAssetId(List<Catalog> actual, List<Catalog> expected) {
-        var actualAssetIds = actual.stream().flatMap(e -> e.getContractOffers().stream()).map(ContractOffer::getAssetId).collect(toList());
-        var expectedAssetIds = expected.stream().flatMap(e -> e.getContractOffers().stream()).map(ContractOffer::getAssetId).collect(toList());
-        assertThat(actualAssetIds).isEqualTo(expectedAssetIds);
-    }
 
     private RequestSpecification baseRequest() {
         return given()

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -14,15 +14,37 @@
 
 package org.eclipse.edc.end2end;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.connector.core.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromCatalogTransformer;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDistributionTransformer;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToActionTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToCatalogTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDataServiceTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDatasetTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDistributionTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToPermissionTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToPolicyTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
 import java.util.UUID;
 
 import static java.time.Duration.ofSeconds;
@@ -32,22 +54,44 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.end2end.TestFunctions.createAssetEntryDto;
 import static org.eclipse.edc.end2end.TestFunctions.createContractDef;
 import static org.eclipse.edc.end2end.TestFunctions.createPolicy;
+import static org.mockito.Mockito.mock;
 
 @EndToEndTest
 class FederatedCatalogTest {
     public static final Duration TIMEOUT = ofSeconds(60);
+    private static TypeTransformerRegistry typeTransformerRegistry;
     private final ManagementApiClient apiClient = createManagementClient();
+
 
     @NotNull
     private static ManagementApiClient createManagementClient() {
         var mapper = JacksonJsonLd.createObjectMapper();
         //needed for ZonedDateTime
         mapper.registerModule(new JavaTimeModule());
-        return new ManagementApiClient(mapper);
+        typeTransformerRegistry = new TypeTransformerRegistryImpl();
+        registerTransformers(Json.createBuilderFactory(Map.of()), mapper);
+        return new ManagementApiClient(mapper, new TitaniumJsonLd(mock(Monitor.class)), typeTransformerRegistry);
+    }
+
+    // registers all the necessary transformers to avoid duplicating their behaviour in mocks
+    private static void registerTransformers(JsonBuilderFactory factory, ObjectMapper mapper) {
+        typeTransformerRegistry.register(new JsonObjectFromCatalogTransformer(factory, mapper));
+        typeTransformerRegistry.register(new JsonObjectFromDatasetTransformer(factory, mapper));
+        typeTransformerRegistry.register(new JsonObjectFromDataServiceTransformer(factory));
+        typeTransformerRegistry.register(new JsonObjectFromPolicyTransformer(factory));
+        typeTransformerRegistry.register(new JsonObjectFromDistributionTransformer(factory));
+        typeTransformerRegistry.register(new JsonObjectToCatalogTransformer());
+        typeTransformerRegistry.register(new JsonObjectToDatasetTransformer());
+        typeTransformerRegistry.register(new JsonObjectToDataServiceTransformer());
+        typeTransformerRegistry.register(new JsonObjectToPolicyTransformer());
+        typeTransformerRegistry.register(new JsonObjectToPermissionTransformer());
+        typeTransformerRegistry.register(new JsonObjectToActionTransformer());
+        typeTransformerRegistry.register(new JsonObjectToDistributionTransformer());
+        typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(mapper));
     }
 
     @Test
-    void crawl_whenOfferAvailable_shouldContainOffer(TestInfo testInfo) {
+    void crawl_whenOfferAvailable_shouldContainOffer(TestInfo testInfo) throws InterruptedException {
         // setup
         var id = String.format("%s-%s", testInfo.getDisplayName(), UUID.randomUUID());
         var asset = createAssetEntryDto(id);
@@ -68,23 +112,27 @@ class FederatedCatalogTest {
         var dr = apiClient.postContractDefinition(request);
         assertThat(dr.succeeded()).withFailMessage(getError(dr)).isTrue();
 
+        var assetIdBase64 = Base64.getEncoder().encodeToString(assetId.getBytes());
         // act-assert
         await().pollDelay(ofSeconds(1))
                 .pollInterval(ofSeconds(1))
                 .atMost(TIMEOUT)
                 .untilAsserted(() -> {
                     var catalogs = apiClient.getContractOffers();
+
                     assertThat(catalogs).hasSizeGreaterThanOrEqualTo(1);
-                    assertThat(catalogs.get(0).getDatasets())
-                            .allSatisfy(dataset -> {
-                                assertThat(dataset.getOffers()).hasSizeGreaterThanOrEqualTo(1);
-                                assertThat(dataset.getOffers().keySet()).anyMatch(key -> key.contains(assetId));
-                            });
+                    assertThat(catalogs).anySatisfy(catalog -> {
+                        assertThat(catalog.getDatasets())
+                                .anySatisfy(dataset -> {
+                                    assertThat(dataset.getOffers()).hasSizeGreaterThanOrEqualTo(1);
+                                    assertThat(dataset.getOffers().keySet()).anyMatch(key -> key.contains(assetIdBase64));
+                                });
+                    });
+
                 });
     }
 
     private String getError(Result<String> r) {
         return ofNullable(r.getFailureDetail()).orElse("No error");
     }
-
 }

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/ManagementApiClient.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/ManagementApiClient.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.end2end;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -24,24 +25,31 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.model.FederatedCatalogCacheQuery;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
 class ManagementApiClient {
     private static final String MANAGEMENT_BASE_URL = "http://localhost:9192/management/v2";
     private static final String CATALOG_BASE_URL = "http://localhost:8181/api";
-    private static final TypeReference<List<Catalog>> LIST_TYPE_REFERENCE = new TypeReference<>() {
+    private static final TypeReference<List<Map<String, Object>>> LIST_TYPE_REFERENCE = new TypeReference<>() {
     };
     private static final MediaType JSON = MediaType.parse("application/json");
     private final ObjectMapper mapper;
+    private final JsonLd jsonLdService;
+    private final TypeTransformerRegistry typeTransformerRegistry;
 
-    ManagementApiClient(ObjectMapper mapper) {
+    ManagementApiClient(ObjectMapper mapper, JsonLd jsonLdService, TypeTransformerRegistry typeTransformerRegistry) {
         this.mapper = mapper;
+        this.jsonLdService = jsonLdService;
+        this.typeTransformerRegistry = typeTransformerRegistry;
     }
 
     private static String mgmt(String path) {
@@ -69,7 +77,14 @@ class ManagementApiClient {
 
         try (var response = getClient().newCall(rq).execute()) {
             if (response.isSuccessful()) {
-                return mapper.readValue(response.body().string(), LIST_TYPE_REFERENCE);
+                var rawJsonLd = response.body().string();
+                var list = mapper.readValue(rawJsonLd, LIST_TYPE_REFERENCE);
+
+                return list.stream().map(m -> {
+                    var jsonObj = jsonLdService.expand(Json.createObjectBuilder(m).build()).getContent();
+                    return typeTransformerRegistry.transform(jsonObj, Catalog.class).getContent();
+                }).toList();
+
             }
             throw new RuntimeException(format("Error getting catalog: %s", response));
         } catch (IOException e) {


### PR DESCRIPTION
## What this PR changes/adds

Upgrades the Federated Catalog's Query API to JSON-LD, to be consistent with the rest of EDC's APIs.

## Why it does that

All our APIs should be JSON-LD-aware. In addition, this fixes a weird bug, where the `Dataset#offers` array was returned empty - most of the time. That's why it's a `fix/` PR.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
