### PR TITLE
chore: adapt code to latest EDC

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -24,22 +24,22 @@ maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-a
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.1, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
-maven/mavencentral/com.github.docker-java/docker-java-api/3.3.4, Apache-2.0, approved, #10346
-maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.4, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
-maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.4, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.docker-java/docker-java-api/3.3.5, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.5, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
+maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
-maven/mavencentral/com.google.guava/guava/31.0.1-jre, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
+maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
+maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, approved, #12173
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
-maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.13.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13403
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -48,11 +48,12 @@ maven/mavencentral/com.squareup.okio/okio/3.6.0, Apache-2.0, approved, #11155
 maven/mavencentral/com.sun.activation/jakarta.activation/2.0.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
 maven/mavencentral/commons-codec/commons-codec/1.11, Apache-2.0 AND BSD-3-Clause, approved, CQ15971
+maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
-maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, Apache-2.0, approved, #11684
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
@@ -91,27 +92,44 @@ maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
-maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
-maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
-maven/mavencentral/org.apache.commons/commons-compress/1.25.0, Apache-2.0, approved, #11600
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
+maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
+maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-lang3/3.11, Apache-2.0, approved, CQ22642
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
+maven/mavencentral/org.apache.commons/commons-text/1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.groovy/groovy-bom/4.0.16, Apache-2.0, approved, #9266
 maven/mavencentral/org.apache.groovy/groovy-json/4.0.16, Apache-2.0, approved, #7411
 maven/mavencentral/org.apache.groovy/groovy-xml/4.0.16, Apache-2.0, approved, #10179
 maven/mavencentral/org.apache.groovy/groovy/4.0.16, Apache-2.0 AND BSD-3-Clause AND MIT, approved, #1742
+maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.1.3, Apache-2.0, approved, #6276
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.1.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13, Apache-2.0, approved, CQ23528
+maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.14, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apache.httpcomponents/httpmime/4.5.13, Apache-2.0, approved, CQ11718
+maven/mavencentral/org.apache.maven.doxia/doxia-core/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-logging-api/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-module-xdoc/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-sink-api/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
+maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
+maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
+maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809
+maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.eclipse.edc/api-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/api-observability/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/asset-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -155,6 +173,7 @@ maven/mavencentral/org.eclipse.edc/dsp-transfer-process-api/0.5.2-SNAPSHOT, Apac
 maven/mavencentral/org.eclipse.edc/dsp-transfer-process-http-dispatcher/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/dsp-transfer-process-transform/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/dsp-transfer-process/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-version-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/dsp/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -280,7 +299,8 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.35, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.4, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/testcontainers/1.19.4, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.6, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/testcontainers/1.19.6, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/core/crawler-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/crawler-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -14,16 +14,11 @@
 
 package org.eclipse.edc.catalog.test;
 
-import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.catalog.spi.DataService;
-import org.eclipse.edc.catalog.spi.Dataset;
-import org.eclipse.edc.catalog.spi.Distribution;
 import org.eclipse.edc.crawler.spi.TargetNode;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -41,16 +36,6 @@ public class TestUtil {
                 .build();
     }
 
-    public static Catalog createCatalog(String id) {
-        var dataService = DataService.Builder.newInstance().build();
-        return Catalog.Builder.newInstance()
-                .id(id)
-                .contractOffers(List.of(createOffer("test-offer")))
-                .dataServices(List.of(dataService))
-                .datasets(List.of(Dataset.Builder.newInstance().distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build()))
-                .properties(new HashMap<>())
-                .build();
-    }
 
     @NotNull
     public static TargetNode createNode() {

--- a/core/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog-core/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 dependencies {
     api(libs.edc.spi.core)
     api(libs.edc.spi.web)
+    api(libs.edc.spi.dsp)
     api(project(":core:crawler-core"))
     api(project(":spi:federated-catalog-spi"))
 
@@ -29,6 +30,7 @@ dependencies {
     implementation(libs.edc.jsonld)
 
     // required for integration test
+    testImplementation(libs.edc.dsp.transform.catalog)
     testImplementation(libs.edc.junit)
     testImplementation(libs.edc.core.transform)
     testImplementation(libs.edc.ext.http)

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
@@ -20,6 +20,10 @@ import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogConstants;
 import org.eclipse.edc.catalog.spi.FederatedCacheStore;
 import org.eclipse.edc.catalog.spi.model.CatalogUpdateResponse;
+import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDistributionTransformer;
 import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
 import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
 import org.eclipse.edc.crawler.spi.TargetNodeFilter;
@@ -76,6 +80,8 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
 
     @Inject
     private Monitor monitor;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
 
     @Override
     public String name() {
@@ -106,6 +112,8 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
                 .nodeDirectory(directory)
                 .nodeFilterFunction(nodeFilter)
                 .build();
+
+        registerTransformers();
     }
 
     @Override
@@ -122,6 +130,13 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
             nodeQueryAdapterRegistry.register(DATASPACE_PROTOCOL, new DspCatalogRequestAction(dispatcherRegistry, context.getMonitor(), mapper, registry, jsonLdService));
         }
         return nodeQueryAdapterRegistry;
+    }
+
+    private void registerTransformers() {
+        transformerRegistry.register(new JsonObjectToCatalogTransformer());
+        transformerRegistry.register(new JsonObjectToDatasetTransformer());
+        transformerRegistry.register(new JsonObjectToDataServiceTransformer());
+        transformerRegistry.register(new JsonObjectToDistributionTransformer());
     }
 
     /**

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/BatchedCatalogRequestFetcher.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/BatchedCatalogRequestFetcher.java
@@ -96,7 +96,7 @@ public class BatchedCatalogRequestFetcher {
 
     private Catalog copyCatalogWithoutNulls(Catalog catalog) {
         return Catalog.Builder.newInstance().id(catalog.getId())
-                .contractOffers(ofNullable(catalog.getContractOffers()).orElseGet(ArrayList::new))
+                .participantId(catalog.getParticipantId())
                 .properties(ofNullable(catalog.getProperties()).orElseGet(HashMap::new))
                 .dataServices(ofNullable(catalog.getDataServices()).orElseGet(ArrayList::new))
                 .datasets(ofNullable(catalog.getDatasets()).orElseGet(ArrayList::new))
@@ -128,7 +128,6 @@ public class BatchedCatalogRequestFetcher {
 
 
     private Catalog concat(Catalog target, Catalog source) {
-        target.getContractOffers().addAll(source.getContractOffers());
         target.getDatasets().addAll(source.getDatasets());
         target.getDataServices().addAll(source.getDataServices());
         target.getProperties().putAll(source.getProperties());

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformer.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.catalog.spi.Catalog;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Dataset;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_PARTICIPANT_ID;
+
+/**
+ * Converts from a DCAT catalog as a {@link JsonObject} in JSON-LD expanded form to a {@link Catalog}.
+ */
+public class JsonObjectToCatalogTransformer extends AbstractJsonLdTransformer<JsonObject, Catalog> {
+
+    public JsonObjectToCatalogTransformer() {
+        super(JsonObject.class, Catalog.class);
+    }
+
+    @Override
+    public @Nullable Catalog transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Catalog.Builder.newInstance();
+
+        builder.id(nodeId(object));
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        return builderResult(builder::build, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, Catalog.Builder builder, TransformerContext context) {
+        if (DCAT_DATASET_ATTRIBUTE.equals(key)) {
+            transformArrayOrObject(value, Dataset.class, builder::dataset, context);
+        } else if (DCAT_DATA_SERVICE_ATTRIBUTE.equals(key)) {
+            transformArrayOrObject(value, DataService.class, builder::dataService, context);
+        } else if (DSPACE_PROPERTY_PARTICIPANT_ID.equals(key)) {
+            builder.participantId(transformString(value, context));
+        } else {
+            builder.property(key, transformGenericProperty(value, context));
+        }
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformer.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_ENDPOINT_URL_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_TERMS_ATTRIBUTE;
+
+/**
+ * Converts from a DCAT data service as a {@link JsonObject} in JSON-LD expanded form to a {@link DataService}.
+ */
+public class JsonObjectToDataServiceTransformer extends AbstractJsonLdTransformer<JsonObject, DataService> {
+
+    public JsonObjectToDataServiceTransformer() {
+        super(JsonObject.class, DataService.class);
+    }
+
+    @Override
+    public @Nullable DataService transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = DataService.Builder.newInstance();
+
+        builder.id(nodeId(object));
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        return builderResult(builder::build, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, DataService.Builder builder, TransformerContext context) {
+        if (DCT_TERMS_ATTRIBUTE.equals(key)) {
+            transformString(value, builder::terms, context);
+        } else if (DCT_ENDPOINT_URL_ATTRIBUTE.equals(key)) {
+            transformString(value, builder::endpointUrl, context);
+        }
+    }
+}
+

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformer.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.catalog.spi.Dataset;
+import org.eclipse.edc.catalog.spi.Distribution;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static jakarta.json.JsonValue.ValueType.ARRAY;
+import static jakarta.json.JsonValue.ValueType.OBJECT;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_ATTRIBUTE;
+
+/**
+ * Converts from a DCAT dataset as a {@link JsonObject} in JSON-LD expanded form to a {@link Dataset}.
+ */
+public class JsonObjectToDatasetTransformer extends AbstractJsonLdTransformer<JsonObject, Dataset> {
+
+    public JsonObjectToDatasetTransformer() {
+        super(JsonObject.class, Dataset.class);
+    }
+
+    @Override
+    public @Nullable Dataset transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Dataset.Builder.newInstance();
+
+        builder.id(nodeId(object));
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        return builderResult(builder::build, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, Dataset.Builder builder, TransformerContext context) {
+        switch (key) {
+            case ODRL_POLICY_ATTRIBUTE -> transformPolicies(value, builder, context);
+            case DCAT_DISTRIBUTION_ATTRIBUTE ->
+                    transformArrayOrObject(value, Distribution.class, builder::distribution, context);
+            default -> builder.property(key, transformGenericProperty(value, context));
+        }
+    }
+
+    private void transformPolicies(JsonValue value, Dataset.Builder builder, TransformerContext context) {
+        if (value instanceof JsonObject object) {
+            var id = nodeId(object);
+            var policy = context.transform(object, Policy.class);
+            builder.offer(id, policy);
+        } else if (value instanceof JsonArray array) {
+            array.forEach(entry -> transformPolicies(entry, builder, context));
+        } else {
+            context.problem()
+                    .unexpectedType()
+                    .type(DCAT_DATASET_TYPE)
+                    .property(ODRL_POLICY_ATTRIBUTE)
+                    .actual(value == null ? "null" : value.getValueType().toString())
+                    .expected(OBJECT)
+                    .expected(ARRAY)
+                    .report();
+        }
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformer.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Distribution;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ACCESS_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+
+/**
+ * Converts from a DCAT distribution as a {@link JsonObject} in JSON-LD expanded form to a {@link Distribution}.
+ */
+public class JsonObjectToDistributionTransformer extends AbstractJsonLdTransformer<JsonObject, Distribution> {
+
+    public JsonObjectToDistributionTransformer() {
+        super(JsonObject.class, Distribution.class);
+    }
+
+    @Override
+    public @Nullable Distribution transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Distribution.Builder.newInstance();
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+        return builderResult(builder::build, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, Distribution.Builder builder, TransformerContext context) {
+        if (DCAT_ACCESS_SERVICE_ATTRIBUTE.equals(key)) {
+            var dataServiceBuilder = DataService.Builder.newInstance();
+            transformString(value, dataServiceBuilder::id, context);
+            builder.dataService(dataServiceBuilder.build());
+        } else if (DCT_FORMAT_ATTRIBUTE.equals(key)) {
+            transformString(value, builder::format, context);
+        }
+    }
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCacheStoreTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCacheStoreTest.java
@@ -17,11 +17,12 @@ package org.eclipse.edc.catalog.defaults.store;
 
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogConstants;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Dataset;
+import org.eclipse.edc.catalog.spi.Distribution;
 import org.eclipse.edc.catalog.store.InMemoryFederatedCacheStore;
 import org.eclipse.edc.connector.core.store.CriterionOperatorRegistryImpl;
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.util.concurrency.LockManager;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,7 @@ class InMemoryFederatedCacheStoreTest {
     void queryCacheContainingOneElementWithNoCriterion_shouldReturnUniqueElement() {
         var contractOfferId = UUID.randomUUID().toString();
         var assetId = UUID.randomUUID().toString();
-        var catalogEntry = createEntry(contractOfferId, createAsset(assetId));
+        var catalogEntry = createCatalog(contractOfferId, createAsset(assetId));
 
         store.save(catalogEntry);
 
@@ -48,15 +49,15 @@ class InMemoryFederatedCacheStoreTest {
 
         assertThat(result)
                 .hasSize(1)
-                .allSatisfy(co -> assertThat(co.getContractOffers().get(0).getAssetId()).isEqualTo(assetId));
+                .allSatisfy(co -> assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId));
     }
 
     @Test
     void queryCacheAfterInsertingSameAssetTwice_shouldReturnLastInsertedContractOfferOnly() {
         var contractOfferId1 = UUID.randomUUID().toString();
         var assetId = UUID.randomUUID().toString();
-        var entry1 = createEntry(contractOfferId1, createAsset(assetId));
-        var entry2 = createEntry(contractOfferId1, createAsset(assetId));
+        var entry1 = createCatalog(contractOfferId1, createAsset(assetId));
+        var entry2 = createCatalog(contractOfferId1, createAsset(assetId));
 
         store.save(entry1);
         store.save(entry2);
@@ -67,8 +68,9 @@ class InMemoryFederatedCacheStoreTest {
                 .hasSize(1)
                 .allSatisfy(co -> {
                     assertThat(co.getId()).isEqualTo(contractOfferId1);
-                    assertThat(co.getContractOffers().get(0).getAssetId()).isEqualTo(assetId);
+                    assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId);
                 });
+
     }
 
     @Test
@@ -77,8 +79,8 @@ class InMemoryFederatedCacheStoreTest {
         var contractOfferId2 = UUID.randomUUID().toString();
         var assetId1 = UUID.randomUUID().toString();
         var assetId2 = UUID.randomUUID().toString();
-        var entry1 = createEntry(contractOfferId1, createAsset(assetId1));
-        var entry2 = createEntry(contractOfferId2, createAsset(assetId2));
+        var entry1 = createCatalog(contractOfferId1, createAsset(assetId1));
+        var entry2 = createCatalog(contractOfferId2, createAsset(assetId2));
 
         store.save(entry1);
         store.save(entry2);
@@ -87,8 +89,8 @@ class InMemoryFederatedCacheStoreTest {
 
         assertThat(result)
                 .hasSize(2)
-                .anySatisfy(co -> assertThat(co.getContractOffers().get(0).getAssetId()).isEqualTo(assetId1))
-                .anySatisfy(co -> assertThat(co.getContractOffers().get(0).getAssetId()).isEqualTo(assetId2));
+                .anySatisfy(co -> assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId1))
+                .anySatisfy(co -> assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId2));
     }
 
     @Test
@@ -97,8 +99,8 @@ class InMemoryFederatedCacheStoreTest {
         var contractOfferId2 = UUID.randomUUID().toString();
         var assetId1 = UUID.randomUUID().toString();
         var assetId2 = UUID.randomUUID().toString();
-        var entry1 = createEntry(contractOfferId1, createAsset(assetId1));
-        var entry2 = createEntry(contractOfferId2, createAsset(assetId2));
+        var entry1 = createCatalog(contractOfferId1, createAsset(assetId1));
+        var entry2 = createCatalog(contractOfferId2, createAsset(assetId2));
 
         store.save(entry1);
         store.save(entry2);
@@ -116,8 +118,8 @@ class InMemoryFederatedCacheStoreTest {
         var contractOfferId2 = UUID.randomUUID().toString();
         var assetId1 = UUID.randomUUID().toString();
         var assetId2 = UUID.randomUUID().toString();
-        var entry1 = createEntry(contractOfferId1, createAsset(assetId1));
-        var entry2 = createEntry(contractOfferId2, createAsset(assetId2));
+        var entry1 = createCatalog(contractOfferId1, createAsset(assetId1));
+        var entry2 = createCatalog(contractOfferId2, createAsset(assetId2));
 
         store.save(entry1);
         store.save(entry2);
@@ -125,11 +127,21 @@ class InMemoryFederatedCacheStoreTest {
         assertThat(store.query(List.of())).hasSize(2);
 
         store.expireAll(); // two items marked
-        store.save(createEntry(UUID.randomUUID().toString(), createAsset(UUID.randomUUID().toString())));
+        store.save(createCatalog(UUID.randomUUID().toString(), createAsset(UUID.randomUUID().toString())));
         store.deleteExpired(); // should delete only marked items
         assertThat(store.query(List.of())).hasSize(1)
                 .doesNotContain(entry1, entry2);
 
+    }
+
+    private Catalog createCatalog(String id, Asset asset) {
+        var dataService = DataService.Builder.newInstance().build();
+        return Catalog.Builder.newInstance()
+                .id(id)
+                .dataServices(List.of(dataService))
+                .datasets(List.of(Dataset.Builder.newInstance().id(asset.getId()).distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build()))
+                .property(CatalogConstants.PROPERTY_ORIGINATOR, "https://test.source/" + id)
+                .build();
     }
 
     private Asset createAsset(String id) {
@@ -137,19 +149,4 @@ class InMemoryFederatedCacheStoreTest {
                 .id(id)
                 .build();
     }
-
-    private ContractOffer createContractOffer(String id, Asset asset) {
-        return ContractOffer.Builder.newInstance()
-                .id(id)
-                .assetId(asset.getId())
-                .policy(Policy.Builder.newInstance().build())
-                .build();
-    }
-
-    private Catalog createEntry(String id, Asset asset) {
-        var offer = createContractOffer("offer-" + id, asset);
-        return Catalog.Builder.newInstance().contractOffers(List.of(offer)).id(id)
-                .property(CatalogConstants.PROPERTY_ORIGINATOR, "http://test.source/" + id).build();
-    }
-
 }

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/BatchedCatalogRequestFetcherTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/BatchedCatalogRequestFetcherTest.java
@@ -25,21 +25,21 @@ import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.catalog.spi.DataService;
 import org.eclipse.edc.catalog.spi.Dataset;
 import org.eclipse.edc.catalog.spi.Distribution;
+import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDistributionTransformer;
 import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
-import org.eclipse.edc.core.transform.transformer.from.JsonObjectFromCatalogTransformer;
-import org.eclipse.edc.core.transform.transformer.from.JsonObjectFromDataServiceTransformer;
-import org.eclipse.edc.core.transform.transformer.from.JsonObjectFromDatasetTransformer;
-import org.eclipse.edc.core.transform.transformer.from.JsonObjectFromDistributionTransformer;
 import org.eclipse.edc.core.transform.transformer.from.JsonObjectFromPolicyTransformer;
-import org.eclipse.edc.core.transform.transformer.to.JsonObjectToCatalogTransformer;
-import org.eclipse.edc.core.transform.transformer.to.JsonObjectToDataServiceTransformer;
-import org.eclipse.edc.core.transform.transformer.to.JsonObjectToDatasetTransformer;
-import org.eclipse.edc.core.transform.transformer.to.JsonObjectToDistributionTransformer;
 import org.eclipse.edc.core.transform.transformer.to.JsonObjectToPolicyTransformer;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
 import org.eclipse.edc.spi.message.Range;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -131,7 +131,7 @@ class BatchedCatalogRequestFetcherTest {
     }
 
     private Catalog emptyCatalog() {
-        return Catalog.Builder.newInstance().id("id").datasets(emptyList()).dataServices(emptyList()).build();
+        return Catalog.Builder.newInstance().id("id").participantId("test-participant").datasets(emptyList()).dataServices(emptyList()).build();
     }
 
     private Catalog createCatalog(int howManyOffers) {
@@ -140,7 +140,7 @@ class BatchedCatalogRequestFetcherTest {
                 .collect(Collectors.toList());
 
         var build = List.of(DataService.Builder.newInstance().build());
-        return Catalog.Builder.newInstance().id("catalog").datasets(datasets).dataServices(build).build();
+        return Catalog.Builder.newInstance().participantId("test-participant").id("catalog").datasets(datasets).dataServices(build).build();
     }
 
     // registers all the necessary transformers to avoid duplicating their behaviour in mocks

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformerTest.java
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Dataset;
+import org.eclipse.edc.catalog.spi.Distribution;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.transform.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToCatalogTransformerTest {
+
+    private static final String CATALOG_ID = "catalogId";
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToCatalogTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToCatalogTransformer();
+    }
+
+    @Test
+    void transform_emptyCatalog_returnCatalog() {
+        var catalog = jsonFactory.createObjectBuilder().add(ID, CATALOG_ID).add(TYPE, DCAT_CATALOG_TYPE).build();
+
+        var result = transformer.transform(getExpanded(catalog), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(CATALOG_ID);
+        assertThat(result.getDatasets()).isNull();
+        assertThat(result.getDataServices()).isNull();
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void transform_catalogWithAdditionalProperty_returnCatalog() {
+        var propertyKey = "catalog:prop:key";
+        var propertyValue = "value";
+
+        when(context.transform(any(JsonValue.class), eq(Object.class))).thenReturn(propertyValue);
+
+        var catalog = jsonFactory.createObjectBuilder()
+                .add(ID, CATALOG_ID)
+                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(propertyKey, propertyValue)
+                .build();
+
+        var result = transformer.transform(getExpanded(catalog), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(CATALOG_ID);
+        assertThat(result.getProperties()).hasSize(1);
+        assertThat(result.getProperties()).containsEntry(propertyKey, propertyValue);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(any(JsonValue.class), eq(Object.class));
+    }
+
+    @Test
+    void transform_filledCatalog_returnCatalog() {
+        var datasetJson = getJsonObject("dataset");
+        var dataServiceJson = getJsonObject("dataService");
+
+        var dataset = Dataset.Builder.newInstance()
+                .offer("offerId", Policy.Builder.newInstance().build())
+                .distribution(Distribution.Builder.newInstance()
+                        .format("format")
+                        .dataService(DataService.Builder.newInstance().build())
+                        .build())
+                .build();
+        var dataService = DataService.Builder.newInstance().build();
+
+        when(context.transform(any(JsonObject.class), eq(Dataset.class)))
+                .thenReturn(dataset);
+        when(context.transform(any(JsonObject.class), eq(DataService.class)))
+                .thenReturn(dataService);
+
+        var catalog = jsonFactory.createObjectBuilder()
+                .add(ID, CATALOG_ID)
+                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(DCAT_DATASET_ATTRIBUTE, datasetJson)
+                .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServiceJson)
+                .build();
+
+        var result = transformer.transform(getExpanded(catalog), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(CATALOG_ID);
+        assertThat(result.getDatasets()).hasSize(1);
+        assertThat(result.getDatasets().get(0)).isEqualTo(dataset);
+        assertThat(result.getDataServices()).hasSize(1);
+        assertThat(result.getDataServices().get(0)).isEqualTo(dataService);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Dataset.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(DataService.class));
+    }
+
+    @Test
+    void transform_invalidType_reportProblem() {
+        var catalog = jsonFactory.createObjectBuilder().add(TYPE, "not-a-catalog").build();
+
+        transformer.transform(getExpanded(catalog), context);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    private JsonObject getJsonObject(String type) {
+        return jsonFactory.createObjectBuilder().add(TYPE, type).build();
+    }
+
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformerTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.transform.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_ENDPOINT_URL_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_TERMS_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+
+class JsonObjectToDataServiceTransformerTest {
+
+    private static final String DATA_SERVICE_ID = "dataServiceId";
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToDataServiceTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDataServiceTransformer();
+    }
+
+    @Test
+    void transform_returnDataService() {
+        var terms = "terms";
+        var url = "url";
+
+        var dataService = jsonFactory.createObjectBuilder()
+                .add(ID, DATA_SERVICE_ID)
+                .add(TYPE, DCAT_DATA_SERVICE_TYPE)
+                .add(DCT_TERMS_ATTRIBUTE, terms)
+                .add(DCT_ENDPOINT_URL_ATTRIBUTE, url)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataService), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATA_SERVICE_ID);
+        assertThat(result.getTerms()).isEqualTo(terms);
+        assertThat(result.getEndpointUrl()).isEqualTo(url);
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void transform_invalidType_reportProblem() {
+        var dataService = jsonFactory.createObjectBuilder().add(TYPE, "not-a-data-service").build();
+
+        transformer.transform(getExpanded(dataService), context);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformerTest.java
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Distribution;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.transform.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToDatasetTransformerTest {
+
+    private static final String DATASET_ID = "datasetId";
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock();
+
+    private JsonObjectToDatasetTransformer transformer;
+
+    private Policy policy;
+    private Distribution distribution;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDatasetTransformer();
+
+        policy = Policy.Builder.newInstance().build();
+        distribution = Distribution.Builder.newInstance()
+                .format("format")
+                .dataService(DataService.Builder.newInstance().build())
+                .build();
+
+        when(context.transform(any(JsonObject.class), eq(Policy.class)))
+                .thenReturn(policy);
+        when(context.transform(any(JsonObject.class), eq(Distribution.class)))
+                .thenReturn(distribution);
+    }
+
+    @Test
+    void transform_returnDataset() {
+        var policyId = "policy-id";
+        var policyJson = getJsonObject(policyId, "policy");
+        var distributionJson = getJsonObject("data-service-id", "dataService");
+
+        var dataset = jsonFactory.createObjectBuilder()
+                .add(ID, DATASET_ID)
+                .add(TYPE, DCAT_DATASET_TYPE)
+                .add(ODRL_POLICY_ATTRIBUTE, policyJson)
+                .add(DCAT_DISTRIBUTION_ATTRIBUTE, distributionJson)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATASET_ID);
+        assertThat(result.getOffers()).hasSize(1);
+        assertThat(result.getOffers()).containsEntry(policyId, policy);
+        assertThat(result.getDistributions()).hasSize(1);
+        assertThat(result.getDistributions().get(0)).isEqualTo(distribution);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Policy.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Distribution.class));
+    }
+
+    @Test
+    void transform_datasetWithAdditionalProperty_returnDataset() {
+        var propertyKey = "dataset:prop:key";
+        var propertyValue = "value";
+
+        when(context.transform(any(JsonValue.class), eq(Object.class))).thenReturn(propertyValue);
+
+        var dataset = jsonFactory.createObjectBuilder()
+                .add(ID, DATASET_ID)
+                .add(TYPE, DCAT_DATASET_TYPE)
+                .add(ODRL_POLICY_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
+                .add(DCAT_DISTRIBUTION_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
+                .add(propertyKey, propertyValue)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATASET_ID);
+        assertThat(result.getProperties()).hasSize(1);
+        assertThat(result.getProperties()).containsEntry(propertyKey, propertyValue);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(any(JsonValue.class), eq(Object.class));
+    }
+
+    private JsonObject getJsonObject(String id, String type) {
+        return jsonFactory.createObjectBuilder()
+                .add(ID, id)
+                .add(TYPE, type)
+                .build();
+    }
+
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformerTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.transform.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ACCESS_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class JsonObjectToDistributionTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToDistributionTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDistributionTransformer();
+    }
+
+    @Test
+    void transform_returnDistribution() {
+        var format = "format";
+        var dataServiceId = "dataServiceId";
+
+        var distribution = jsonFactory.createObjectBuilder()
+                .add(TYPE, DCAT_DISTRIBUTION_TYPE)
+                .add(DCT_FORMAT_ATTRIBUTE, format)
+                .add(DCAT_ACCESS_SERVICE_ATTRIBUTE, dataServiceId)
+                .build();
+
+        var result = transformer.transform(getExpanded(distribution), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getFormat()).isEqualTo(format);
+        assertThat(result.getDataService()).isNotNull()
+                .matches(ds -> ds.getId().equals(dataServiceId) && ds.getTerms() == null && ds.getEndpointUrl() == null);
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void transform_invalidType_reportProblem() {
+        var distribution = jsonFactory.createObjectBuilder()
+                .add(TYPE, "not-a-distribution")
+                .build();
+
+        transformer.transform(getExpanded(distribution), context);
+
+        verify(context, times(1)).reportProblem(anyString());
+    }
+
+    @Test
+    void transform_requiredAttributesMissing_reportProblem() {
+        var distribution = jsonFactory.createObjectBuilder()
+                .add(TYPE, DCAT_DISTRIBUTION_TYPE)
+                .build();
+
+        var result = transformer.transform(getExpanded(distribution), context);
+
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(anyString());
+    }
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/TestInput.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/TestInput.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.JsonObject;
+
+import static com.apicatalog.jsonld.JsonLd.expand;
+
+/**
+ * Functions for shaping test input.
+ */
+public class TestInput {
+
+    private TestInput() {
+    }
+
+    /**
+     * Expands test input as Json-ld is required to be in this form
+     */
+    public static JsonObject getExpanded(JsonObject message) {
+        try {
+            return expand(JsonDocument.of(message)).get().asJsonArray().getJsonObject(0);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -48,8 +48,8 @@ public class TestUtil {
     public static Catalog createCatalog(String id) {
         var dataService = DataService.Builder.newInstance().build();
         return Catalog.Builder.newInstance()
+                .participantId("test-participant")
                 .id(id)
-                .contractOffers(List.of(createOffer("test-offer")))
                 .dataServices(List.of(dataService))
                 .datasets(List.of(Dataset.Builder.newInstance().distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build()))
                 .properties(new HashMap<>())

--- a/extensions/api/federated-catalog-api/build.gradle.kts
+++ b/extensions/api/federated-catalog-api/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     testImplementation(libs.edc.dsp.api.configuration)
     testImplementation(libs.restAssured)
     testImplementation(libs.edc.iam.mock)
+    testImplementation(libs.edc.jsonld)
+    testImplementation(libs.edc.dsp.transform.catalog)
+
 }
 
 edcBuild {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-spi-catalog = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
+edc-spi-dsp = { module = "org.eclipse.edc:dsp-spi", version.ref = "edc" }
 edc-spi-jsonld = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" }
 edc-spi-transform = { module = "org.eclipse.edc:transform-spi", version.ref = "edc" }
 edc-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
@@ -42,6 +43,7 @@ restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssu
 # protocol modules
 edc-dsp-api-configuration = { module = "org.eclipse.edc:dsp-api-configuration", version.ref = "edc" }
 edc-dsp-all = { module = "org.eclipse.edc:dsp", version.ref = "edc" }
+edc-dsp-transform-catalog = { module = "org.eclipse.edc:dsp-catalog-transform", version.ref = "edc" }
 
 [bundles]
 edc-connector = ["edc-boot", "edc-core-connector", "edc-core-jersey", "edc-api-observability"]

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
@@ -90,7 +90,8 @@ public class CatalogRuntimeComponentTest {
                 // give the runtime time to set up everything
                 "edc.catalog.cache.execution.delay.seconds", "1",
                 "web.http.port", valueOf(TestFunctions.PORT),
-                "web.http.path", TestFunctions.BASE_PATH
+                "web.http.path", TestFunctions.BASE_PATH,
+                "edc.participant.id", "test-participant"
         ));
         dispatcher = mock(DspHttpRemoteMessageDispatcher.class);
         when(dispatcher.protocol()).thenReturn(DATASPACE_PROTOCOL);

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
@@ -39,7 +39,6 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,11 +82,11 @@ public class TestFunctions {
 
     public static Catalog.Builder catalogBuilder() {
         return Catalog.Builder.newInstance()
+                .participantId("test-participant")
                 .id(UUID.randomUUID().toString())
                 .properties(new HashMap<>())
                 .dataServices(new ArrayList<>())
-                .datasets(new ArrayList<>())
-                .contractOffers(Collections.emptyList());
+                .datasets(new ArrayList<>());
     }
 
     public static CompletableFuture<StatusResult<byte[]>> catalogOf(Function<Catalog, StatusResult<byte[]>> transformationFunction, String catId, Dataset... datasets) {

--- a/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
+++ b/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 dependencies {
     testImplementation(project(":spi:federated-catalog-spi"))
     testImplementation(project(":core:federated-catalog-core"))
+    testImplementation(libs.edc.dsp.transform.catalog)
     testImplementation(libs.awaitility)
     testImplementation(libs.edc.api.management)
     testImplementation(libs.edc.core.transform)


### PR DESCRIPTION
## What this PR changes/adds

This PR adapts the FCC code base to the latest changes in upstream EDC, most notably:
- restores the `JsonObjectTo...` transformers, that were removed from upstream code in [this commit](https://github.com/eclipse-edc/Connector/commit/2857d375a5d158f8de8fe5cafa9a19d6c619dd33)
- registers the transformers
- adapts package names / imports for the existing catalog transformers
- adds the `participantId` to catalogs in tests

## Why it does that

keep in-step with upstream

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
