### PR TITLE
docs: fix catalog swagger API

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -39,7 +39,7 @@ maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, ap
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.13.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13403
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, , restricted, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225

--- a/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApi.java
+++ b/extensions/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApi.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.catalog.api.query;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,14 +26,16 @@ import jakarta.json.JsonArray;
 import org.eclipse.edc.catalog.spi.model.FederatedCatalogCacheQuery;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
-@OpenAPIDefinition
+@OpenAPIDefinition(
+        info = @Info(description = "This represents the Federated Catalog API. It serves the cached Catalogs fetched from the data providers.",
+                title = "Federated Catalog API", version = "1"))
 @Tag(name = "Federated Catalog")
 public interface FederatedCatalogApi {
-    @Operation(description = "Obtains all contract offers currently held by this cache instance",
+    @Operation(description = "Obtains all Catalog currently held by this cache instance",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "A list of contract offers is returned, potentially empty",
+                    @ApiResponse(responseCode = "200", description = "A list of Catalog is returned, potentially empty",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractOffer.class)))),
-                    @ApiResponse(responseCode = "50x", description = "A Query could not be completed due to an internal error")
+                    @ApiResponse(responseCode = "500", description = "A Query could not be completed due to an internal error")
             }
 
     )


### PR DESCRIPTION
## What this PR changes/adds

Fix swagger API:
 - adds `info` section
 - remove `50x` status code which is not supported

## Why it does that

Documentation.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
