### PR TITLE
Correct typo in module name in end2end test README

### DIFF
--- a/system-tests/end2end-test/README.md
+++ b/system-tests/end2end-test/README.md
@@ -23,7 +23,7 @@ Please follow these steps in order to run the tests on a local dev environment.
    will later be used in docker containers. In order to build them, simply execute
    ```shell
    ./gradlew :system-tests:end2end-test:catalog-runtime:shadowJar
-   ./gradlew :system-tests:end2end-test:conenctor-runtime:shadowJar
+   ./gradlew :system-tests:end2end-test:connector-runtime:shadowJar
    ```
 
 2. Run `docker-compose`: from you project root directory execute the following command to bring up the test backend


### PR DESCRIPTION
## What this PR changes/adds

This PR addresses a small typo in the READMe of the end to end test package.

## Why it does that

With the corrected typo, one can copy paste and run the shell example directly.
