### PR TITLE
fix: configure control path/port in test

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -28,7 +28,6 @@ maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.1, Apache-2.0, approve
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
-maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.crypto.tink/tink/1.13.0, Apache-2.0, approved, #14502
@@ -38,8 +37,8 @@ maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, C
 maven/mavencentral/com.google.guava/guava/33.1.0-jre, Apache-2.0 AND CC0-1.0, approved, #13675
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.16.0, , restricted, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.38, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.16.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #14689
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -68,6 +68,7 @@ class FederatedCatalogTest {
     private static final Endpoint CONNECTOR_MANAGEMENT = new Endpoint("/management", "8081");
     private static final Endpoint CONNECTOR_PROTOCOL = new Endpoint("/api/v1/dsp", "8082");
     private static final Endpoint CONNECTOR_DEFAULT = new Endpoint("/api/v1/", "8080");
+    private static final Endpoint CONNECTOR_CONTROL = new Endpoint("/api/v1/control", "8093");
 
     private static final Endpoint CATALOG_MANAGEMENT = new Endpoint("/management", "8091");
     private static final Endpoint CATALOG_PROTOCOL = new Endpoint("/api/v1/dsp", "8092");
@@ -81,6 +82,8 @@ class FederatedCatalogTest {
                     "web.http.path", CONNECTOR_DEFAULT.path(),
                     "web.http.protocol.port", CONNECTOR_PROTOCOL.port(),
                     "web.http.protocol.path", CONNECTOR_PROTOCOL.path(),
+                    "web.http.control.port", CONNECTOR_CONTROL.port(),
+                    "web.http.control.path", CONNECTOR_CONTROL.path(),
                     "web.http.management.port", CONNECTOR_MANAGEMENT.port(),
                     "edc.participant.id", "test-connector",
                     "web.http.management.path", CONNECTOR_MANAGEMENT.path(),


### PR DESCRIPTION
## What this PR changes/adds

Properly configures the `control` context for the test runtime

## Why it does that

A recent refactoring upstream requires this

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
