### PR TITLE
fix(build): repair broken launcher

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -42,6 +42,28 @@ jobs:
         with:
           command: ./gradlew test jacocoTestReport
 
+  Verify-Launcher:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+
+      - name: 'Build launcher'
+        run: ./gradlew :launchers:shadowJar
+
+      - name: 'Build Docker image'
+        run: docker build -t federated-catalog ./launchers
+
+      - name: 'Start FCC Container'
+        run: |
+          docker run -d --rm --name fcc federated-catalog:latest
+
+      - name: 'Wait for Federated Catalog to be healthy'
+        uses: raschmitt/wait-for-healthy-container@v1
+        with:
+          container-name: fcc
+          timeout: 60
+
   Postgresql-Integration-Tests:
     runs-on: ubuntu-latest
     if: ${{ false }}

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -88,9 +88,9 @@ maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.2, BSD-3-Clause, ap
 maven/mavencentral/javax.servlet/javax.servlet-api/3.1.0, (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ7248
 maven/mavencentral/javax.ws.rs/javax.ws.rs-api/2.1, (CDDL-1.1 OR GPL-2.0 WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ18121
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
@@ -297,7 +297,7 @@ maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.10.2, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
-maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
+maven/mavencentral/org.mockito/mockito-core/5.12.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #14678
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713

--- a/launchers/build.gradle.kts
+++ b/launchers/build.gradle.kts
@@ -21,7 +21,20 @@ plugins {
 dependencies {
     runtimeOnly(project(":core:federated-catalog-core"))
     runtimeOnly(project(":extensions:api:federated-catalog-api"))
+    runtimeOnly(project(":spi:federated-catalog-spi"))
+    runtimeOnly(libs.edc.lib.util)
+    runtimeOnly(libs.edc.spi.jsonld)
+
     runtimeOnly(libs.bundles.edc.connector)
+    runtimeOnly(libs.edc.core.controlplane)
+    runtimeOnly(libs.edc.core.jetty)
+    runtimeOnly(libs.edc.core.dataPlane.selector)
+    runtimeOnly(libs.edc.lib.providers.jersey)
+    runtimeOnly(libs.edc.lib.boot)
+
+
+    runtimeOnly(libs.edc.dsp.all)
+    runtimeOnly(libs.edc.iam.mock)
 }
 
 application {


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes the broken launcher, that missed some dependencies. I also added a test to verify the launcher can boot up correctly.

## Why it does that

After the upstream package refactoring a while ago, some runtime dependencies were missing

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #193

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
