### PR TITLE
fix(transform): make sure Distributions are never null

### DIFF
--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformer.java
@@ -25,6 +25,8 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+
 import static jakarta.json.JsonValue.ValueType.ARRAY;
 import static jakarta.json.JsonValue.ValueType.OBJECT;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_TYPE;
@@ -45,6 +47,7 @@ public class JsonObjectToDatasetTransformer extends AbstractJsonLdTransformer<Js
         var builder = Dataset.Builder.newInstance();
 
         builder.id(nodeId(object));
+        builder.distributions(new ArrayList<>());
         visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
 
         return builderResult(builder::build, context);

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformerTest.java
@@ -125,6 +125,32 @@ class JsonObjectToDatasetTransformerTest {
         verify(context, times(1)).transform(any(JsonValue.class), eq(Object.class));
     }
 
+    @Test
+    void transform_dataset_withoutDistribution() {
+        var policyId = "policy-id";
+        var policyJson = getJsonObject(policyId, "policy");
+        var distributionJson = jsonFactory.createArrayBuilder().build();
+
+        var dataset = jsonFactory.createObjectBuilder()
+                .add(ID, DATASET_ID)
+                .add(TYPE, DCAT_DATASET_TYPE)
+                .add(ODRL_POLICY_ATTRIBUTE, policyJson)
+                .add(DCAT_DISTRIBUTION_ATTRIBUTE, distributionJson)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATASET_ID);
+        assertThat(result.getOffers()).hasSize(1);
+        assertThat(result.getOffers()).containsEntry(policyId, policy);
+        assertThat(result.getDistributions()).isNotNull().isEmpty();
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Policy.class));
+        verify(context, never()).transform(isA(JsonObject.class), eq(Distribution.class));
+    }
+
     private JsonObject getJsonObject(String id, String type) {
         return jsonFactory.createObjectBuilder()
                 .add(ID, id)


### PR DESCRIPTION
## What this PR changes/adds

the list of `distribution` objects in the `DataSet` class can be null. For the purposes of the FC we always should initialize the list, even if no distribution is there.

I don't know if this is mandated by the DCAT spec or not, but in FC it makes things easier if it's not `null`.

## Why it does that

ease of use when processing catalogs, that contain datasets without distributions.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
