### PR TITLE
feat: add global disable flag for Crawlers

### DIFF
--- a/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
+++ b/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
@@ -57,12 +57,17 @@ public class ExecutionManager {
     private int numCrawlers = 1;
     private CrawlerActionRegistry crawlerActionRegistry;
     private CrawlerSuccessHandler successHandler;
+    private boolean enabled = true;
 
     private ExecutionManager() {
         nodeFilter = n -> true;
     }
 
     public void executePlan(ExecutionPlan plan) {
+        if (!enabled) {
+            monitor.warning("Execution of crawlers is globally disabled.");
+            return;
+        }
         plan.run(() -> {
             runPreExecution();
             doWork();
@@ -213,6 +218,11 @@ public class ExecutionManager {
 
         public Builder numCrawlers(int numCrawlers) {
             instance.numCrawlers = numCrawlers;
+            return this;
+        }
+
+        public Builder isEnabled(boolean isEnabled) {
+            instance.enabled = isEnabled;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

adds a flag to disable the Federated Catalog Crawlers globally

## Why it does that

in some circumstances it might be useful to disable the crawlers, for example when proper configuration is missing.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
