### PR TITLE
fix: add nested catalog test + types registration

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -93,7 +93,6 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.1, Apache-2.0, approved, 
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.16, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
@@ -313,15 +312,12 @@ maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearly
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.2.0, EPL-2.0, approved, #11857
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.3, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.3, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.3, EPL-2.0, approved, #15250
-maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.2, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.3, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.3, EPL-2.0, approved, #9709
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.3, EPL-2.0, approved, #15216
-maven/mavencentral/org.junit/junit-bom/5.10.2, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.10.3, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCache.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCache.java
@@ -44,6 +44,7 @@ public class SqlFederatedCatalogCache extends AbstractSqlStore implements Federa
 
     @Override
     public void save(Catalog catalog) {
+
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var id = ofNullable(catalog.getProperties().get(CatalogConstants.PROPERTY_ORIGINATOR))

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtension.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtension.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.catalog.store.sql;
 
 import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
 import org.eclipse.edc.catalog.store.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
@@ -48,6 +50,7 @@ public class SqlFederatedCatalogCacheExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        typeManager.registerTypes(Catalog.class, Dataset.class);
         var store = new SqlFederatedCatalogCache(dataSourceRegistry, getDataSourceName(context), trxContext,
                 typeManager.getMapper(), queryExecutor, getStatementImpl());
         context.registerService(FederatedCatalogCache.class, store);

--- a/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtensionTest.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtensionTest.java
@@ -14,8 +14,10 @@
 
 package org.eclipse.edc.catalog.store.sql;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
-import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
@@ -35,9 +37,12 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DependencyInjectionExtension.class)
 public class SqlFederatedCatalogCacheExtensionTest {
 
+    private final TypeManager typeManager = mock();
+
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
-        context.registerService(TypeManager.class, new JacksonTypeManager());
+        context.registerService(TypeManager.class, typeManager);
+        when(typeManager.getMapper()).thenReturn(new ObjectMapper());
     }
 
     @Test
@@ -51,6 +56,7 @@ public class SqlFederatedCatalogCacheExtensionTest {
         var service = context.getService(FederatedCatalogCache.class);
         assertThat(service).isInstanceOf(SqlFederatedCatalogCache.class);
 
+        verify(typeManager).registerTypes(Catalog.class, Dataset.class);
         verify(config).getString(DATASOURCE_NAME_SETTING, DataSourceRegistry.DEFAULT_DATASOURCE);
     }
 }

--- a/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheTest.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheTest.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.catalog.store.sql;
 import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
 import org.eclipse.edc.catalog.spi.testfixtures.FederatedCatalogCacheTestBase;
 import org.eclipse.edc.catalog.store.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.sql.QueryExecutor;
@@ -32,7 +34,7 @@ import java.nio.file.Paths;
 @ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 public class SqlFederatedCatalogCacheTest extends FederatedCatalogCacheTestBase {
-    
+
     private final FederatedCatalogCacheStatements statements = new PostgresDialectStatements();
 
     private FederatedCatalogCache store;
@@ -40,6 +42,7 @@ public class SqlFederatedCatalogCacheTest extends FederatedCatalogCacheTestBase 
     @BeforeEach
     void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
         var typeManager = new JacksonTypeManager();
+        typeManager.registerTypes(Catalog.class, Dataset.class);
         store = new SqlFederatedCatalogCache(extension.getDataSourceRegistry(), extension.getDatasourceName(),
                 extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
 

--- a/spi/federated-catalog-spi/src/testFixtures/java/org/eclipse/edc/catalog/spi/testfixtures/FederatedCatalogCacheTestBase.java
+++ b/spi/federated-catalog-spi/src/testFixtures/java/org/eclipse/edc/catalog/spi/testfixtures/FederatedCatalogCacheTestBase.java
@@ -46,12 +46,14 @@ public abstract class FederatedCatalogCacheTestBase {
 
     private Catalog.Builder createCatalogBuilder(String id, Asset asset, String ednpointUrl) {
         var dataService = DataService.Builder.newInstance().endpointUrl(ednpointUrl).build();
+        var dataset = Dataset.Builder.newInstance().id(asset.getId()).properties(asset.getProperties()).distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build();
 
+        var nestedCatalog = Catalog.Builder.newInstance().participantId("participantId").build();
 
         return Catalog.Builder.newInstance()
                 .id(id)
                 .dataServices(List.of(dataService))
-                .datasets(List.of(Dataset.Builder.newInstance().id(asset.getId()).properties(asset.getProperties()).distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build()))
+                .datasets(List.of(dataset, nestedCatalog))
                 .property(CatalogConstants.PROPERTY_ORIGINATOR, "https://test.source/" + id);
     }
 
@@ -80,7 +82,10 @@ public abstract class FederatedCatalogCacheTestBase {
 
             assertThat(result)
                     .hasSize(1)
-                    .allSatisfy(co -> assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId));
+                    .allSatisfy(co -> {
+                        assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId);
+                        assertThat(co.getDatasets().get(1)).isInstanceOf(Catalog.class);
+                    });
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Fixes JSON serde for Catalog when datasets contains an embedded catalog by
registering `Catalog` and `Dataset` types in the `TypeManager` where now `Dataset` is polymorphic https://github.com/eclipse-edc/Connector/pull/4362 



## Why it does that

bugfix

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
