### PR TITLE
refactor: separate sql stores from datasources

### DIFF
--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtension.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -34,8 +35,11 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = "SQL federated catalog cache")
 public class SqlFederatedCatalogCacheExtension implements ServiceExtension {
 
+    @Deprecated(since = "0.8.1")
     @Setting
-    public static final String DATASOURCE_NAME_SETTING = "edc.datasource.federatedcatalog.name";
+    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.federatedcatalog.name";
+    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_NAME = "edc.sql.store.federatedcatalog.datasource";
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -70,6 +74,6 @@ public class SqlFederatedCatalogCacheExtension implements ServiceExtension {
     }
 
     private String getDataSourceName(ServiceExtensionContext context) {
-        return context.getConfig().getString(DATASOURCE_NAME_SETTING, DataSourceRegistry.DEFAULT_DATASOURCE);
+        return DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
     }
 }

--- a/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtensionTest.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/store/sql/SqlFederatedCatalogCacheExtensionTest.java
@@ -22,14 +22,14 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.catalog.store.sql.SqlFederatedCatalogCacheExtension.DATASOURCE_NAME_SETTING;
+import static org.eclipse.edc.catalog.store.sql.SqlFederatedCatalogCacheExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,6 +57,6 @@ public class SqlFederatedCatalogCacheExtensionTest {
         assertThat(service).isInstanceOf(SqlFederatedCatalogCache.class);
 
         verify(typeManager).registerTypes(Catalog.class, Dataset.class);
-        verify(config).getString(DATASOURCE_NAME_SETTING, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Separate datasource from sql store configuration

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #237 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
