### PR TITLE
fix: avoid exception DSP Request Action

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -11,7 +11,7 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.1, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.2, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.2, Apache-2.0 AND MIT, approved, #11602
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.2, , approved, #13665
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.2, Apache-2.0 AND MIT, approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.1, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.2, Apache-2.0, approved, #13671
@@ -36,11 +36,12 @@ maven/mavencentral/com.google.crypto.tink/tink/1.15.0, Apache-2.0, approved, cle
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.28.0, Apache-2.0, approved, #15107
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
-maven/mavencentral/com.google.guava/guava/33.3.0-jre, Apache-2.0 AND CC0-1.0 AND (Apache-2.0 AND CC-PDDC) AND (Apache-2.0 AND CC0-1.0), approved, #15952
+maven/mavencentral/com.google.guava/guava/33.3.1-jre, Apache-2.0 AND CC0-1.0 AND (Apache-2.0 AND CC-PDDC) AND (Apache-2.0 AND CC0-1.0), approved, #15952
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
+maven/mavencentral/com.google.j2objc/j2objc-annotations/3.0.0, Apache-2.0, approved, #13676
 maven/mavencentral/com.google.protobuf/protobuf-java/3.25.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.41.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.18.1, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #16060
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.18.2, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #16060
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #15227
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -65,7 +66,7 @@ maven/mavencentral/io.rest-assured/rest-assured/5.5.0, Apache-2.0, approved, #15
 maven/mavencentral/io.rest-assured/xml-path/5.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.22, Apache-2.0, approved, #5947
-maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.23, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.24, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.22, Apache-2.0, approved, #11362
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.22, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.22, Apache-2.0, approved, #9265
@@ -92,12 +93,12 @@ maven/mavencentral/javax.servlet/javax.servlet-api/3.1.0, (CDDL-1.1 OR GPL-2.0-o
 maven/mavencentral/javax.ws.rs/javax.ws.rs-api/2.1, (CDDL-1.1 OR GPL-2.0 WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ18121
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.1, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.15.0, Apache-2.0, approved, #16009
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.15.2, Apache-2.0, approved, #16009
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.bytebuddy/byte-buddy/1.15.0, Apache-2.0 AND BSD-3-Clause, approved, #16008
+maven/mavencentral/net.bytebuddy/byte-buddy/1.15.2, Apache-2.0 AND BSD-3-Clause, approved, #16008
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
-maven/mavencentral/net.sf.saxon/Saxon-HE/12.5, MPL-2.0-no-copyleft-exception AND (LicenseRef-scancode-proprietary-license AND MPL-2.0-no-copyleft-exception) AND (MPL-2.0-no-copyleft-exception AND X11) AND (MIT AND MPL-2.0-no-copyleft-exception) AND (MPL-1.0 AND MPL-2.0-no-copyleft-exception) AND (Apache-2.0 AND MPL-2.0-no-copyleft-exception) AND MPL-1.0, restricted, #16061
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.5, W3C-19980720 AND MPL-2.0 AND MPL-1.0, approved, #16061
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.2, BSD-3-Clause, approved, #10767
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-lang3/3.11, Apache-2.0, approved, CQ22642
@@ -130,7 +131,7 @@ maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78.1, MIT AND CC0-1.0, appr
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78.1, MIT, approved, #14435
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.46.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.47.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
 maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809
 maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined
@@ -141,6 +142,7 @@ maven/mavencentral/org.eclipse.edc/api-observability/0.10.0-SNAPSHOT, Apache-2.0
 maven/mavencentral/org.eclipse.edc/asset-api/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/asset-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/auth-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-tokenbased/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-lib/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -197,6 +199,7 @@ maven/mavencentral/org.eclipse.edc/identity-trust-core/0.10.0-SNAPSHOT, Apache-2
 maven/mavencentral/org.eclipse.edc/identity-trust-issuers-configuration/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-service/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-sts-accounts-api/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-sts-api/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-sts-client-configuration/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-sts-core/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -306,15 +309,18 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.9.10, Apache-2.0, a
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.10, Apache-2.0, approved, #11827
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.jetbrains/annotations/25.0.0, , restricted, clearlydefined
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.11.0, EPL-2.0, approved, #15935
-maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.11.0, EPL-2.0, approved, #15939
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.11.0, EPL-2.0, approved, #15940
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.11.1, EPL-2.0, approved, #15935
+maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.11.1, EPL-2.0, approved, #15939
+maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.11.1, EPL-2.0, approved, #15940
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.11.0, EPL-2.0, approved, #15936
-maven/mavencentral/org.junit.platform/junit-platform-engine/1.11.0, EPL-2.0, approved, #15932
+maven/mavencentral/org.junit.platform/junit-platform-commons/1.11.1, EPL-2.0, approved, #15936
+maven/mavencentral/org.junit.platform/junit-platform-engine/1.11.1, EPL-2.0, approved, #15932
 maven/mavencentral/org.junit/junit-bom/5.11.0, EPL-2.0, approved, #16062
+maven/mavencentral/org.junit/junit-bom/5.11.1, EPL-2.0, approved, #16062
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
-maven/mavencentral/org.mockito/mockito-core/5.13.0, MIT, approved, clearlydefined
+maven/mavencentral/org.mockito/mockito-core/5.14.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #16375
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713

--- a/core/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog-core/build.gradle.kts
@@ -37,12 +37,16 @@ dependencies {
     implementation(libs.edc.json.ld.lib)
     implementation(libs.edc.lib.store)
 
-    // required for integration test
-    testImplementation(libs.edc.dsp.transform.catalog)
     testImplementation(libs.edc.junit)
     testImplementation(libs.edc.ext.http)
     testImplementation(libs.awaitility)
 
     testImplementation(testFixtures(project(":spi:federated-catalog-spi")))
     testImplementation(testFixtures(project(":spi:crawler-spi")))
+
+    // required for integration test
+    testFixturesImplementation(libs.edc.core.connector)
+    testFixturesImplementation(libs.edc.dsp.transform.catalog)
+    testFixturesImplementation(libs.edc.json.ld.lib)
+    testFixturesImplementation(libs.edc.controlplane.transform)
 }

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestAction.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestAction.java
@@ -99,7 +99,9 @@ public class DspCatalogRequestAction implements CrawlerAction {
                 .map(ur -> (CatalogUpdateResponse) ur)
                 .map(CatalogUpdateResponse::getCatalog);
 
-        var datasets = new ArrayList<>(partitions.get(Dataset.class));
+        var datasets = ofNullable(partitions.get(Dataset.class))
+                .map(ds -> new ArrayList<>(ds))
+                .orElseGet(ArrayList::new);
         expandedSubCatalogs.forEach(datasets::add);
         return completedFuture(copy(rootCatalog, datasets).build());
 

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.query;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.catalog.spi.model.CatalogUpdateResponse;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.crawler.spi.model.UpdateRequest;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.test.TestUtil.createCatalog;
+import static org.eclipse.edc.catalog.test.TestUtil.registerTransformers;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DspCatalogRequestActionTest {
+
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock();
+    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final TitaniumJsonLd jsonLdService = new TitaniumJsonLd(mock());
+    private final ObjectMapper objectMapper = createObjectMapper();
+    private final DspCatalogRequestAction action = new DspCatalogRequestAction(dispatcherRegistry, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
+
+    @BeforeEach
+    void setup() {
+        registerTransformers(typeTransformerRegistry);
+    }
+
+    @Test
+    void apply_withFlatCatalog() {
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+
+        var catalog = toBytes(createCatalog("test-catalog-id"));
+        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(catalog));
+
+        assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
+            if (updateResponse instanceof CatalogUpdateResponse cr) {
+                return cr.getCatalog() != null &&
+                        cr.getCatalog().getId().equals("test-catalog-id") &&
+                        cr.getSource().equals("https://example.com/test-node-id");
+            }
+            return false;
+        });
+    }
+
+    @Test
+    void apply_withOnlyNestedCatalog() {
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+
+        var rootCatalog = createCatalog("root-catalog-id");
+        rootCatalog.getDatasets().clear();
+        var nestedCatalog = createCatalog("nested-catalog-id");
+        rootCatalog.getDatasets().add(nestedCatalog);
+
+        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(toBytes(rootCatalog)))
+                .thenReturn(completedFuture(toBytes(nestedCatalog)));
+
+        assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
+            if (updateResponse instanceof CatalogUpdateResponse cr) {
+                return cr.getCatalog() != null &&
+                        cr.getCatalog().getId().equals("root-catalog-id") &&
+                        cr.getSource().equals("https://example.com/test-node-id") &&
+                        cr.getCatalog().getDatasets().stream().allMatch(dataset -> dataset.getId().equals("nested-catalog-id"));
+            }
+            return false;
+        }, "Contains nested catalog datasets");
+    }
+
+    @Test
+    void apply_withRootDatasets_andNestedCatalog() {
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+
+        var rootCatalog = createCatalog("root-catalog-id");
+        var nestedCatalog = createCatalog("nested-catalog-id");
+        rootCatalog.getDatasets().add(nestedCatalog);
+
+        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(toBytes(rootCatalog)))
+                .thenReturn(completedFuture(toBytes(nestedCatalog)));
+
+        assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
+            if (updateResponse instanceof CatalogUpdateResponse cr) {
+                return cr.getCatalog() != null &&
+                        cr.getCatalog().getId().equals("root-catalog-id") &&
+                        cr.getSource().equals("https://example.com/test-node-id") &&
+                        cr.getCatalog().getDatasets().stream()
+                                .allMatch(dataset -> dataset.getId().equals("nested-catalog-id") ||
+                                        dataset.getId().equals("root-catalog-id-dataset"));
+            }
+            return false;
+        }, "Contains root catalog datasets plus nested catalog datasets");
+    }
+
+    private StatusResult<byte[]> toBytes(Catalog catalog) {
+        try {
+            var jo = typeTransformerRegistry.transform(catalog, JsonObject.class).getContent();
+            var expanded = jsonLdService.expand(jo).getContent();
+            var expandedStr = objectMapper.writeValueAsString(expanded);
+            return StatusResult.success(expandedStr.getBytes());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/PagingCatalogFetcherTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/query/PagingCatalogFetcherTest.java
@@ -16,30 +16,13 @@ package org.eclipse.edc.catalog.query;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.catalog.cache.query.PagingCatalogFetcher;
 import org.eclipse.edc.catalog.spi.CatalogConstants;
-import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
-import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
-import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
-import org.eclipse.edc.catalog.transform.JsonObjectToDistributionTransformer;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
-import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
-import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
-import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
-import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
-import org.eclipse.edc.connector.controlplane.transform.odrl.to.JsonObjectToPolicyTransformer;
-import org.eclipse.edc.connector.core.agent.NoOpParticipantIdMapper;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
-import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.annotations.ComponentTest;
-import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogTransformer;
-import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
-import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
-import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
 import org.eclipse.edc.spi.message.Range;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -48,14 +31,11 @@ import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.test.TestUtil.createCatalog;
+import static org.eclipse.edc.catalog.test.TestUtil.registerTransformers;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
@@ -76,7 +56,7 @@ class PagingCatalogFetcherTest {
 
     @BeforeEach
     void setup() {
-        registerTransformers();
+        registerTransformers(typeTransformerRegistry);
 
         fetcher = new PagingCatalogFetcher(dispatcherRegistryMock, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
     }
@@ -109,13 +89,6 @@ class PagingCatalogFetcherTest {
                 .containsExactly(new Range(0, 5), new Range(5, 10), new Range(10, 15));
     }
 
-    public Dataset createDataset(String id) {
-        return Dataset.Builder.newInstance()
-                .offer("test-offer", Policy.Builder.newInstance().build())
-                .distribution(Distribution.Builder.newInstance().format("test-format").dataService(DataService.Builder.newInstance().build()).build())
-                .id(id)
-                .build();
-    }
 
     private StatusResult<byte[]> toBytes(Catalog catalog) throws JsonProcessingException {
         var jo = typeTransformerRegistry.transform(catalog, JsonObject.class).getContent();
@@ -133,32 +106,6 @@ class PagingCatalogFetcherTest {
 
     private Catalog emptyCatalog() {
         return Catalog.Builder.newInstance().id("id").participantId("test-participant").datasets(emptyList()).dataServices(emptyList()).build();
-    }
-
-    private Catalog createCatalog(int howManyOffers) {
-        var datasets = IntStream.range(0, howManyOffers)
-                .mapToObj(i -> createDataset("dataset-" + i))
-                .collect(Collectors.toList());
-
-        var build = List.of(DataService.Builder.newInstance().build());
-        return Catalog.Builder.newInstance().participantId("test-participant").id("catalog").datasets(datasets).dataServices(build).build();
-    }
-
-    // registers all the necessary transformers to avoid duplicating their behaviour in mocks
-    private void registerTransformers() {
-        var factory = Json.createBuilderFactory(Map.of());
-        var mapper = JacksonJsonLd.createObjectMapper();
-        var participantIdMapper = new NoOpParticipantIdMapper();
-        typeTransformerRegistry.register(new JsonObjectFromCatalogTransformer(factory, mapper, participantIdMapper));
-        typeTransformerRegistry.register(new JsonObjectFromDatasetTransformer(factory, mapper));
-        typeTransformerRegistry.register(new JsonObjectFromDataServiceTransformer(factory));
-        typeTransformerRegistry.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper));
-        typeTransformerRegistry.register(new JsonObjectFromDistributionTransformer(factory));
-        typeTransformerRegistry.register(new JsonObjectToCatalogTransformer());
-        typeTransformerRegistry.register(new JsonObjectToDatasetTransformer());
-        typeTransformerRegistry.register(new JsonObjectToDataServiceTransformer());
-        typeTransformerRegistry.register(new JsonObjectToPolicyTransformer(participantIdMapper));
-        typeTransformerRegistry.register(new JsonObjectToDistributionTransformer());
     }
 
 }

--- a/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -14,25 +14,51 @@
 
 package org.eclipse.edc.catalog.test;
 
+import jakarta.json.Json;
+import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDistributionTransformer;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.connector.controlplane.transform.odrl.to.JsonObjectToPolicyTransformer;
+import org.eclipse.edc.connector.core.agent.NoOpParticipantIdMapper;
 import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class TestUtil {
 
     public static final String TEST_PROTOCOL = "test-protocol";
 
     public static Catalog createCatalog(String id) {
-        var dataService = DataService.Builder.newInstance().build();
+        var dataService = DataService.Builder.newInstance()
+                .endpointUrl("https://test-dataservice.endpoint.url")
+                .endpointDescription("test endpoint description")
+                .build();
         return buildCatalog(id)
-                .datasets(List.of(Dataset.Builder.newInstance().id(id + "-dataset").distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build()))
+                .datasets(List.of(Dataset.Builder.newInstance()
+                        .id(id + "-dataset")
+                        .distributions(List.of(Distribution.Builder.newInstance()
+                                .dataService(dataService)
+                                .format("test-format").build()))
+                        .build()))
                 .dataServices(List.of(dataService))
                 .build();
     }
@@ -48,4 +74,39 @@ public class TestUtil {
     public static TargetNode createNode() {
         return new TargetNode("testnode" + UUID.randomUUID(), "did:web:" + UUID.randomUUID(), "http://test.com", List.of(TEST_PROTOCOL));
     }
+
+    public static Catalog createCatalog(int howManyOffers) {
+        var datasets = IntStream.range(0, howManyOffers)
+                .mapToObj(i -> createDataset("dataset-" + i))
+                .collect(Collectors.toList());
+
+        var build = List.of(DataService.Builder.newInstance().build());
+        return Catalog.Builder.newInstance().participantId("test-participant").id("catalog").datasets(datasets).dataServices(build).build();
+    }
+
+    public static Dataset createDataset(String id) {
+        return Dataset.Builder.newInstance()
+                .offer("test-offer", Policy.Builder.newInstance().build())
+                .distribution(Distribution.Builder.newInstance().format("test-format").dataService(DataService.Builder.newInstance().build()).build())
+                .id(id)
+                .build();
+    }
+
+    // registers all the necessary transformers to avoid duplicating their behaviour in mocks
+    public static void registerTransformers(TypeTransformerRegistry typeTransformerRegistry1) {
+        var factory = Json.createBuilderFactory(Map.of());
+        var mapper = JacksonJsonLd.createObjectMapper();
+        var participantIdMapper = new NoOpParticipantIdMapper();
+        typeTransformerRegistry1.register(new JsonObjectFromCatalogTransformer(factory, mapper, participantIdMapper));
+        typeTransformerRegistry1.register(new JsonObjectFromDatasetTransformer(factory, mapper));
+        typeTransformerRegistry1.register(new JsonObjectFromDataServiceTransformer(factory));
+        typeTransformerRegistry1.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper));
+        typeTransformerRegistry1.register(new JsonObjectFromDistributionTransformer(factory));
+        typeTransformerRegistry1.register(new JsonObjectToCatalogTransformer());
+        typeTransformerRegistry1.register(new JsonObjectToDatasetTransformer());
+        typeTransformerRegistry1.register(new JsonObjectToDataServiceTransformer());
+        typeTransformerRegistry1.register(new JsonObjectToPolicyTransformer(participantIdMapper));
+        typeTransformerRegistry1.register(new JsonObjectToDistributionTransformer());
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Fixes a potential exception in the `DspCatalogRequestAction` that parses nested catalogs.

## Why it does that

avoids a potential NPE when a root catalog contains only a nested catalog but no other datasets

## Further notes

- moves some test methods into the `testFixtures` package

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
