### PR TITLE
fix: enable publishing the DCP BOM

### DIFF
--- a/dist/bom/federatedcatalog-dcp-bom/build.gradle.kts
+++ b/dist/bom/federatedcatalog-dcp-bom/build.gradle.kts
@@ -31,7 +31,3 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("fc.jar")
 }
-
-edcBuild {
-    publish.set(false)
-}


### PR DESCRIPTION
## What this PR changes/adds

enables the publication for the FC DCP BOM

## Why it does that

it wasn't enabled before.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
