### PR TITLE
feat(ci): use E2E tests for BOM Smoke tests

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -125,15 +125,3 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: eclipse-edc/.github/.github/workflows/verify-openapi.yml@main
     secrets: inherit
-
-  Verify-FC-BOM:
-    strategy:
-      fail-fast: false
-
-      # we can't test the "controlplane-oauth2-com" because it only starts successfully if the public key is already in the vault
-      matrix:
-        bom-directory: [ "dist/bom/federatedcatalog-dcp-bom" ]
-    uses: eclipse-edc/.github/.github/workflows/verify-bom.yml@main
-    with:
-      module-dir: ${{ matrix.bom-directory }}
-      properties-file: example.properties

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ include(":launchers:catalog-mocked")
 include(":system-tests:component-tests")
 include(":system-tests:end2end-test:connector-runtime")
 include(":system-tests:end2end-test:e2e-junit-runner")
+include(":system-tests:bom-tests")
 include(":version-catalog")
 
 // BOM modules

--- a/system-tests/bom-tests/build.gradle.kts
+++ b/system-tests/bom-tests/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    java
+}
+
+dependencies {
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.restAssured)
+    testImplementation(libs.assertj)
+    testImplementation(libs.awaitility)
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.bom;
+
+
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+
+
+public class BomSmokeTests {
+    abstract static class SmokeTest {
+        public static final String DEFAULT_PORT = "8080";
+        public static final String DEFAULT_PATH = "/api";
+
+        @Test
+        void assertRuntimeReady() {
+            await().untilAsserted(() -> given()
+                    .baseUri("http://localhost:" + DEFAULT_PORT + DEFAULT_PATH + "/check/startup")
+                    .get()
+                    .then()
+                    .statusCode(200)
+                    .log().ifValidationFails()
+                    .body("isSystemHealthy", equalTo(true)));
+
+        }
+    }
+
+    @Nested
+    @EndToEndTest
+    class FederatedCatalogDcp extends SmokeTest {
+
+        @RegisterExtension
+        protected RuntimeExtension runtime =
+                new RuntimePerMethodExtension(new EmbeddedRuntime("fc-dcp-bom",
+                        Map.of(
+                                "edc.iam.sts.oauth.token.url", "https://sts.com/token",
+                                "edc.iam.sts.oauth.client.id", "test-clientid",
+                                "edc.iam.sts.oauth.client.secret.alias", "test-alias",
+                                "web.http.port", "8080",
+                                "web.http.path", "/api",
+                                "web.http.catalog.port", "8081",
+                                "web.http.catalog.path", "/api/catalog",
+                                "edc.catalog.cache.execution.period.seconds", "5",
+                                "edc.catalog.cache.execution.delay.seconds", "0"),
+                        ":dist:bom:federatedcatalog-dcp-bom"
+                ));
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

use E2E tests for BOM smoke tests

## Why it does that

more mockable, more stable test methodology


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
