### PR TITLE
Fix: add missing JsonObjectToCriterionTransformer

### DIFF
--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
@@ -50,6 +50,7 @@ import org.eclipse.edc.spi.system.health.HealthCheckResult;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
 
@@ -156,6 +157,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectToDataServiceTransformer());
         transformerRegistry.register(new JsonObjectToDistributionTransformer());
         transformerRegistry.register(new JsonObjectToQuerySpecTransformer());
+        transformerRegistry.register(new JsonObjectToCriterionTransformer());
 
         var jsonFactory = Json.createBuilderFactory(Map.of());
         var mapper = context.getService(TypeManager.class).getMapper(JSON_LD);


### PR DESCRIPTION
## What this PR changes/adds

Registers a  `JsonObjectToCriterionTransformer` with the `transformerRegistry` in `FederatedCatalogCacheExtension`.

## Why it does that

The `FederatedCatalogCacheExtension` was not registering a `JsonObjectToCriterionTransformer`. This caused any calls to `/v1alpha/catalog/query` that contained a `QuerySpec` with a non empty `filterExpression` to fail with an internal server error because the `filterExpression` JsonArray could not be converted to a list of `Criterion.class`.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #266