### PR TITLE
fix: check the correct port for the container

### DIFF
--- a/launchers/catalog-dcp/Dockerfile
+++ b/launchers/catalog-dcp/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 8182
 ENV WEB_HTTP_PORT="8181"
 ENV WEB_HTTP_PATH="/api"
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/$WEB_HTTP_PATH/check/health
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT$WEB_HTTP_PATH/check/health
 
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable

--- a/launchers/catalog-dcp/Dockerfile
+++ b/launchers/catalog-dcp/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 8182
 ENV WEB_HTTP_PORT="8181"
 ENV WEB_HTTP_PATH="/api"
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/api/check/health
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/$WEB_HTTP_PATH/check/health
 
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable

--- a/launchers/catalog-dcp/Dockerfile
+++ b/launchers/catalog-dcp/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 8182
 ENV WEB_HTTP_PORT="8181"
 ENV WEB_HTTP_PATH="/api"
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:8181/api/check/health
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/api/check/health
 
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable

--- a/launchers/catalog-mocked/Dockerfile
+++ b/launchers/catalog-mocked/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 8182
 ENV WEB_HTTP_PORT="8181"
 ENV WEB_HTTP_PATH="/api"
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/$WEB_HTTP_PATH/check/health
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT$WEB_HTTP_PATH/check/health
 
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable

--- a/launchers/catalog-mocked/Dockerfile
+++ b/launchers/catalog-mocked/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 8182
 ENV WEB_HTTP_PORT="8181"
 ENV WEB_HTTP_PATH="/api"
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/api/check/health
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/$WEB_HTTP_PATH/check/health
 
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable

--- a/launchers/catalog-mocked/Dockerfile
+++ b/launchers/catalog-mocked/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 8182
 ENV WEB_HTTP_PORT="8181"
 ENV WEB_HTTP_PATH="/api"
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:8181/api/check/health
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:$WEB_HTTP_PORT/api/check/health
 
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 # ARG can not be used in ENTRYPOINT so storing value in an ENV variable


### PR DESCRIPTION
## What this PR changes/adds

Set up the correct health check for the Dockerfile.

## Why it does that

When starting the container and changing the WEB_HTTP_PORT environment, the container is unhealthy.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #276 
