### PR TITLE
fix: sql-duplicate-class-fqcn

### DIFF
--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/BaseSqlDialectStatements.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.cache.sql;
 
-import org.eclipse.edc.catalog.store.sql.schema.postgres.FederatedCatalogMapping;
+import org.eclipse.edc.catalog.cache.sql.schema.postgres.FederatedCatalogMapping;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/FederatedCatalogCacheStatements.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/FederatedCatalogCacheStatements.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.cache.sql;
 
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.statement.SqlStatements;

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCache.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCache.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.cache.sql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.catalog.spi.CatalogConstants;

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/FederatedCatalogMapping.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/FederatedCatalogMapping.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql.schema.postgres;
+package org.eclipse.edc.catalog.cache.sql.schema.postgres;
 
-import org.eclipse.edc.catalog.store.sql.FederatedCatalogCacheStatements;
+import org.eclipse.edc.catalog.cache.sql.FederatedCatalogCacheStatements;
 import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PostgresDialectStatements.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql.schema.postgres;
+package org.eclipse.edc.catalog.cache.sql.schema.postgres;
 
-import org.eclipse.edc.catalog.store.sql.BaseSqlDialectStatements;
+import org.eclipse.edc.catalog.cache.sql.BaseSqlDialectStatements;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
 import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PrefixedJsonFieldTranslator.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PrefixedJsonFieldTranslator.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql.schema.postgres;
+package org.eclipse.edc.catalog.cache.sql.schema.postgres;
 
 import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.util.reflection.PathItem;

--- a/extensions/store/sql/federated-catalog-cache-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,4 +12,4 @@
 #
 #
 
-org.eclipse.edc.catalog.store.sql.SqlFederatedCatalogCacheExtension
+org.eclipse.edc.catalog.cache.sql.SqlFederatedCatalogCacheExtension

--- a/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheExtensionTest.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Amadeus IT Group
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,15 +8,16 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Amadeus IT Group - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.cache.sql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.edc.crawler.spi.TargetNode;
-import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
-public class SqlTargetNodeDirectoryExtensionTest {
+public class SqlFederatedCatalogCacheExtensionTest {
 
     private final TypeManager typeManager = mock();
 
@@ -43,16 +44,16 @@ public class SqlTargetNodeDirectoryExtensionTest {
     }
 
     @Test
-    void shouldInitializeTheStore(SqlTargetNodeDirectoryExtension extension, ServiceExtensionContext context) {
+    void shouldInitializeTheStore(SqlFederatedCatalogCacheExtension extension, ServiceExtensionContext context) {
         var config = mock(Config.class);
         when(context.getConfig()).thenReturn(config);
         when(config.getString(any(), any())).thenReturn("test");
 
         extension.initialize(context);
 
-        var service = context.getService(TargetNodeDirectory.class);
-        assertThat(service).isInstanceOf(SqlTargetNodeDirectory.class);
+        var service = context.getService(FederatedCatalogCache.class);
+        assertThat(service).isInstanceOf(SqlFederatedCatalogCache.class);
 
-        verify(typeManager).registerTypes(TargetNode.class);
+        verify(typeManager).registerTypes(Catalog.class, Dataset.class);
     }
 }

--- a/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheTest.java
+++ b/extensions/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheTest.java
@@ -12,11 +12,11 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.cache.sql;
 
+import org.eclipse.edc.catalog.cache.sql.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
 import org.eclipse.edc.catalog.spi.testfixtures.FederatedCatalogCacheTestBase;
-import org.eclipse.edc.catalog.store.sql.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.json.JacksonTypeManager;

--- a/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/BaseSqlDialectStatements.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.directory.sql;
 
-import org.eclipse.edc.catalog.store.sql.schema.postgres.TargetNodeMapping;
+import org.eclipse.edc.catalog.directory.sql.schema.postgres.TargetNodeMapping;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;

--- a/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectory.java
+++ b/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectory.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.directory.sql;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtension.java
+++ b/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Amadeus IT Group
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,16 +8,15 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Amadeus IT Group - initial API and implementation
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.directory.sql;
 
-import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
-import org.eclipse.edc.catalog.store.sql.schema.postgres.PostgresDialectStatements;
-import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
-import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.catalog.directory.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
@@ -30,11 +29,11 @@ import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
-@Provides(FederatedCatalogCache.class)
-@Extension(value = "SQL federated catalog cache")
-public class SqlFederatedCatalogCacheExtension implements ServiceExtension {
+@Provides(TargetNodeDirectory.class)
+@Extension(value = "SQL target node directory")
+public class SqlTargetNodeDirectoryExtension implements ServiceExtension {
 
-    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.federatedcatalog.datasource")
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.targetnodedirectory.datasource")
     private String dataSourceName;
 
     @Inject
@@ -42,7 +41,7 @@ public class SqlFederatedCatalogCacheExtension implements ServiceExtension {
     @Inject
     private TransactionContext trxContext;
     @Inject(required = false)
-    private FederatedCatalogCacheStatements statements;
+    private TargetNodeStatements statements;
     @Inject
     private TypeManager typeManager;
 
@@ -54,17 +53,17 @@ public class SqlFederatedCatalogCacheExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        typeManager.registerTypes(Catalog.class, Dataset.class);
-        var store = new SqlFederatedCatalogCache(dataSourceRegistry, dataSourceName, trxContext,
+        typeManager.registerTypes(TargetNode.class);
+        var targetNodeDirectory = new SqlTargetNodeDirectory(dataSourceRegistry, dataSourceName, trxContext,
                 typeManager.getMapper(), queryExecutor, getStatementImpl());
-        context.registerService(FederatedCatalogCache.class, store);
-        sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "cache-schema.sql");
+        context.registerService(TargetNodeDirectory.class, targetNodeDirectory);
+        sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "target-node-directory-schema.sql");
     }
 
     /**
      * returns an externally-provided sql statement dialect, or postgres as a default
      */
-    private FederatedCatalogCacheStatements getStatementImpl() {
+    private TargetNodeStatements getStatementImpl() {
         return statements != null ? statements : new PostgresDialectStatements();
     }
 

--- a/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/TargetNodeStatements.java
+++ b/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/TargetNodeStatements.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.directory.sql;
 
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.statement.SqlStatements;

--- a/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/PostgresDialectStatements.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql.schema.postgres;
+package org.eclipse.edc.catalog.directory.sql.schema.postgres;
 
-import org.eclipse.edc.catalog.store.sql.BaseSqlDialectStatements;
+import org.eclipse.edc.catalog.directory.sql.BaseSqlDialectStatements;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
 
 public class PostgresDialectStatements extends BaseSqlDialectStatements {

--- a/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/TargetNodeMapping.java
+++ b/extensions/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/TargetNodeMapping.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql.schema.postgres;
+package org.eclipse.edc.catalog.directory.sql.schema.postgres;
 
-import org.eclipse.edc.catalog.store.sql.TargetNodeStatements;
+import org.eclipse.edc.catalog.directory.sql.TargetNodeStatements;
 import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 

--- a/extensions/store/sql/target-node-directory-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/store/sql/target-node-directory-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,4 +12,4 @@
 #
 #
 
-org.eclipse.edc.catalog.store.sql.SqlTargetNodeDirectoryExtension
+org.eclipse.edc.catalog.directory.sql.SqlTargetNodeDirectoryExtension

--- a/extensions/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtensionTest.java
+++ b/extensions/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Amadeus IT Group
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,16 +8,15 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Amadeus IT Group - initial API and implementation
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.directory.sql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
-import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
-import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
@@ -33,7 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
-public class SqlFederatedCatalogCacheExtensionTest {
+public class SqlTargetNodeDirectoryExtensionTest {
 
     private final TypeManager typeManager = mock();
 
@@ -44,16 +43,16 @@ public class SqlFederatedCatalogCacheExtensionTest {
     }
 
     @Test
-    void shouldInitializeTheStore(SqlFederatedCatalogCacheExtension extension, ServiceExtensionContext context) {
+    void shouldInitializeTheStore(SqlTargetNodeDirectoryExtension extension, ServiceExtensionContext context) {
         var config = mock(Config.class);
         when(context.getConfig()).thenReturn(config);
         when(config.getString(any(), any())).thenReturn("test");
 
         extension.initialize(context);
 
-        var service = context.getService(FederatedCatalogCache.class);
-        assertThat(service).isInstanceOf(SqlFederatedCatalogCache.class);
+        var service = context.getService(TargetNodeDirectory.class);
+        assertThat(service).isInstanceOf(SqlTargetNodeDirectory.class);
 
-        verify(typeManager).registerTypes(Catalog.class, Dataset.class);
+        verify(typeManager).registerTypes(TargetNode.class);
     }
 }

--- a/extensions/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryTest.java
+++ b/extensions/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryTest.java
@@ -12,10 +12,10 @@
  *
  */
 
-package org.eclipse.edc.catalog.store.sql;
+package org.eclipse.edc.catalog.directory.sql;
 
+import org.eclipse.edc.catalog.directory.sql.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.catalog.spi.testfixtures.TargetNodeDirectoryTestBase;
-import org.eclipse.edc.catalog.store.sql.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.crawler.spi.TargetNodeDirectory;


### PR DESCRIPTION
## What this PR changes/adds

Renames packages in:
module `federated-catalog-cache-sql`: `org.eclipse.edc.catalog.store.sql.*` to `org.eclipse.edc.catalog.cache.sql.*`
module `target-node-directory-sql`: `org.eclipse.edc.catalog.store.sql.*` to  `org.eclipse.edc.catalog.directory.sql.*`

## Why it does that

The duplicate package names could cause a conflict in class resolution. Especially because `PostgresDialectStatements` ends up having the same FQCN in both modules.

## Further notes


## Who will sponsor this feature?

@ndr-brt 

## Linked Issue(s)

Closes #286 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
