### PR TITLE
fix: remove invalid service definition from module fc-core

### DIFF
--- a/core/federated-catalog-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/federated-catalog-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,2 +1,1 @@
-org.eclipse.edc.catalog.cache.FederatedCatalogCacheExtension
 org.eclipse.edc.catalog.cache.FederatedCatalogDefaultServicesExtension


### PR DESCRIPTION
## What this PR changes/adds

Removes the invalid service definition `org.eclipse.edc.catalog.cache.FederatedCatalogCacheExtension` from 
`META-INF/services/org.eclipse.edc.spi.system.ServiceExtension` in the `federated-catalog-core` module.  


## Why it does that

The referenced class is not part of the `federated-catalog-core` module but only exists in 
`federated-catalog-core-2025` and the deprecated `federated-catalog-core-08` modules.  
Keeping the service definition in `federated-catalog-core` caused a `ServiceConfigurationError` when neither of those 
modules are included at runtime.  

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?
@ndr-brt 


## Linked Issue(s)

Closes #342

