### PR TITLE
chore: fix compile issue after upstream changes

### DIFF
--- a/core/federated-catalog-core-08/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/core/federated-catalog-core-08/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.controlplane.transform.odrl.to.JsonObjectToPoli
 import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogTransformer;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
@@ -72,6 +73,9 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
     @Inject
     private TypeTransformerRegistry transformerRegistry;
 
+    @Inject
+    private SingleParticipantContextSupplier singleParticipantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -88,7 +92,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
             nodeQueryAdapterRegistry = new CrawlerActionRegistryImpl();
             // catalog queries via IDS multipart and DSP are supported by default
             var mapper = typeManager.getMapper(JSON_LD);
-            nodeQueryAdapterRegistry.register(DATASPACE_PROTOCOL, new DspCatalogRequestAction(dispatcherRegistry, context.getMonitor(), mapper, registry.forContext(DSP_TRANSFORMER_CONTEXT_V_08), jsonLdService));
+            nodeQueryAdapterRegistry.register(DATASPACE_PROTOCOL, new DspCatalogRequestAction(dispatcherRegistry, singleParticipantContextSupplier, context.getMonitor(), mapper, registry.forContext(DSP_TRANSFORMER_CONTEXT_V_08), jsonLdService));
         }
         return nodeQueryAdapterRegistry;
     }

--- a/core/federated-catalog-core-08/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
+++ b/core/federated-catalog-core-08/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
@@ -22,8 +22,11 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.crawler.spi.model.UpdateRequest;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +48,8 @@ class DspCatalogRequestActionTest {
     private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
     private final TitaniumJsonLd jsonLdService = new TitaniumJsonLd(mock());
     private final ObjectMapper objectMapper = createObjectMapper();
-    private final DspCatalogRequestAction action = new DspCatalogRequestAction(dispatcherRegistry, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
+    private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantContext"));
+    private final DspCatalogRequestAction action = new DspCatalogRequestAction(dispatcherRegistry, participantContextSupplier, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
 
     @BeforeEach
     void setup() {
@@ -57,7 +61,7 @@ class DspCatalogRequestActionTest {
         var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
 
         var catalog = toBytes(createCatalog("test-catalog-id"));
-        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(catalog));
 
         assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
@@ -79,7 +83,7 @@ class DspCatalogRequestActionTest {
         var nestedCatalog = createCatalog("nested-catalog-id");
         rootCatalog.getDatasets().add(nestedCatalog);
 
-        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(toBytes(rootCatalog)))
                 .thenReturn(completedFuture(toBytes(nestedCatalog)));
 
@@ -102,7 +106,7 @@ class DspCatalogRequestActionTest {
         var nestedCatalog = createCatalog("nested-catalog-id");
         rootCatalog.getDatasets().add(nestedCatalog);
 
-        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(toBytes(rootCatalog)))
                 .thenReturn(completedFuture(toBytes(nestedCatalog)));
 

--- a/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.controlplane.transform.odrl.to.JsonObjectToPoli
 import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
@@ -68,6 +69,8 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
     private JsonLd jsonLdService;
     @Inject
     private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
 
     @Override
     public String name() {
@@ -85,7 +88,7 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
             nodeQueryAdapterRegistry = new CrawlerActionRegistryImpl();
             // catalog queries via IDS multipart and DSP are supported by default
             var mapper = typeManager.getMapper(JSON_LD);
-            nodeQueryAdapterRegistry.register(DATASPACE_PROTOCOL, new DspCatalogRequestAction(dispatcherRegistry, context.getMonitor(), mapper, registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1), jsonLdService));
+            nodeQueryAdapterRegistry.register(DATASPACE_PROTOCOL, new DspCatalogRequestAction(dispatcherRegistry, participantContextSupplier, context.getMonitor(), mapper, registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1), jsonLdService));
         }
         return nodeQueryAdapterRegistry;
     }

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
@@ -22,8 +22,11 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.crawler.spi.model.UpdateRequest;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +48,8 @@ class DspCatalogRequestActionTest {
     private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
     private final TitaniumJsonLd jsonLdService = new TitaniumJsonLd(mock());
     private final ObjectMapper objectMapper = createObjectMapper();
-    private final DspCatalogRequestAction action = new DspCatalogRequestAction(dispatcherRegistry, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
+    private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantContext"));
+    private final DspCatalogRequestAction action = new DspCatalogRequestAction(dispatcherRegistry, participantContextSupplier, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
 
     @BeforeEach
     void setup() {
@@ -57,7 +61,7 @@ class DspCatalogRequestActionTest {
         var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
 
         var catalog = toBytes(createCatalog("test-catalog-id"));
-        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(catalog));
 
         assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
@@ -79,7 +83,7 @@ class DspCatalogRequestActionTest {
         var nestedCatalog = createCatalog("nested-catalog-id");
         rootCatalog.getDatasets().add(nestedCatalog);
 
-        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(toBytes(rootCatalog)))
                 .thenReturn(completedFuture(toBytes(nestedCatalog)));
 
@@ -102,7 +106,7 @@ class DspCatalogRequestActionTest {
         var nestedCatalog = createCatalog("nested-catalog-id");
         rootCatalog.getDatasets().add(nestedCatalog);
 
-        when(dispatcherRegistry.dispatch(eq(byte[].class), any(CatalogRequestMessage.class)))
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(toBytes(rootCatalog)))
                 .thenReturn(completedFuture(toBytes(nestedCatalog)));
 

--- a/core/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog-core/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(libs.edc.spi.web)
     api(libs.edc.spi.catalog)
     api(libs.edc.spi.dsp)
+    api(libs.edc.spi.participant.single)
     api(project(":core:crawler-core"))
     api(project(":spi:federated-catalog-spi"))
     api(project(":core:common:lib:catalog-util-lib"))

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestAction.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestAction.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.crawler.spi.CrawlerAction;
 import org.eclipse.edc.crawler.spi.model.UpdateRequest;
 import org.eclipse.edc.crawler.spi.model.UpdateResponse;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
@@ -43,8 +44,9 @@ public class DspCatalogRequestAction implements CrawlerAction {
     private static final int BATCH_SIZE = 100;
     private final PagingCatalogFetcher fetcher;
 
-    public DspCatalogRequestAction(RemoteMessageDispatcherRegistry dispatcherRegistry, Monitor monitor, ObjectMapper objectMapper, TypeTransformerRegistry transformerRegistry, JsonLd jsonLdService) {
-        fetcher = new PagingCatalogFetcher(dispatcherRegistry, monitor, objectMapper, transformerRegistry, jsonLdService);
+    public DspCatalogRequestAction(RemoteMessageDispatcherRegistry dispatcherRegistry, SingleParticipantContextSupplier participantContextSupplier,
+                                   Monitor monitor, ObjectMapper objectMapper, TypeTransformerRegistry transformerRegistry, JsonLd jsonLdService) {
+        fetcher = new PagingCatalogFetcher(dispatcherRegistry, participantContextSupplier, monitor,  objectMapper, transformerRegistry, jsonLdService);
     }
 
     @Override

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ edc-spi-jsonld = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" }
 edc-spi-transform = { module = "org.eclipse.edc:transform-spi", version.ref = "edc" }
 edc-spi-dataplane-selector = { module = "org.eclipse.edc:data-plane-selector-spi", version.ref = "edc" }
 edc-spi-transaction-datasource = { module = "org.eclipse.edc:transaction-datasource-spi", version.ref = "edc" }
+edc-spi-participant-single = { module = "org.eclipse.edc:participant-context-single-spi", version.ref = "edc" }
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }
 
 # EDC libs

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
@@ -66,6 +66,7 @@ import static org.eclipse.edc.catalog.spi.CatalogConstants.DATASPACE_PROTOCOL;
 import static org.eclipse.edc.catalog.spi.CatalogConstants.PROPERTY_ORIGINATOR;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -110,7 +111,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog)));
 
         await().pollDelay(ofSeconds(1))
@@ -129,7 +130,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 5))
                 .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog))); // this is important, otherwise there is an endless loop!
 
@@ -148,7 +149,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenReturn(randomCatalog(catalog -> StatusResult.success(TestUtils.getResourceFileContentAsString("catalog_of_catalogs.json").getBytes()), "root-catalog-id", 5))
                 .thenReturn(randomCatalog(catalog -> StatusResult.success(TestUtils.getResourceFileContentAsString("catalog.json").getBytes()), "sub-catalog-id", 5));
 
@@ -171,7 +172,7 @@ public class CatalogRuntimeComponentTest {
 
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 100))
                 .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 100))
                 .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 50));
@@ -183,7 +184,7 @@ public class CatalogRuntimeComponentTest {
                     assertThat(catalogs.size()).isEqualTo(1);
                     assertThat(catalogs.get(0).getDatasets()).hasSize(250);
                 });
-        verify(dispatcher, atLeast(3)).dispatch(eq(byte[].class), isA(CatalogRequestMessage.class));
+        verify(dispatcher, atLeast(3)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
 
     }
 
@@ -195,7 +196,7 @@ public class CatalogRuntimeComponentTest {
 
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(TEST_CATALOG_ID).datasets(new ArrayList<>(List.of(
                         createDataset("offer1"), createDataset("offer2"), createDataset("offer3")
                 ))).build())))
@@ -211,7 +212,7 @@ public class CatalogRuntimeComponentTest {
                     assertThat(catalogs).hasSize(1);
                     assertThat(catalogs.get(0).getDatasets()).hasSize(2)
                             .noneMatch(offer -> offer.getId().equals("offer3"));
-                    verify(dispatcher, atLeast(4)).dispatch(eq(byte[].class), isA(CatalogRequestMessage.class));
+                    verify(dispatcher, atLeast(4)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
                 });
 
     }
@@ -224,7 +225,7 @@ public class CatalogRuntimeComponentTest {
 
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(TEST_CATALOG_ID).datasets(new ArrayList<>(List.of(
                         createDataset("offer1"), createDataset("offer2"), createDataset("offer3")
                 ))).build())))
@@ -239,7 +240,7 @@ public class CatalogRuntimeComponentTest {
                     var catalogs = queryCatalogApi(jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
                     assertThat(catalogs).hasSize(1);
                     assertThat(catalogs.get(0).getDatasets()).hasSize(3);
-                    verify(dispatcher, atLeast(4)).dispatch(eq(byte[].class), isA(CatalogRequestMessage.class));
+                    verify(dispatcher, atLeast(4)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
                 });
 
     }
@@ -252,7 +253,7 @@ public class CatalogRuntimeComponentTest {
 
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenAnswer(a -> completedFuture(toBytes(ttr, catalogBuilder().id("test-cat")
                         .datasets(List.of(createDataset("dataset1"), createDataset("dataset2"))).build())))
                 .thenAnswer(a -> completedFuture(toBytes(ttr, catalogBuilder().id("test-cat")
@@ -268,7 +269,7 @@ public class CatalogRuntimeComponentTest {
                             .allSatisfy(cat -> assertThat(cat.getDatasets()).hasSize(4))
                             .allSatisfy(co -> assertThat(co.getDatasets().stream().map(Dataset::getId).map(id -> id.replace("dataset", "")))
                                     .containsExactlyInAnyOrder("1", "2", "3", "4"));
-                    verify(dispatcher, atLeast(2)).dispatch(eq(byte[].class), isA(CatalogRequestMessage.class));
+                    verify(dispatcher, atLeast(2)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
                 });
 
     }
@@ -280,7 +281,7 @@ public class CatalogRuntimeComponentTest {
         insertSingle(directory);
         // intercept request egress
         reg.register(DATASPACE_PROTOCOL, dispatcher);
-        when(dispatcher.dispatch(eq(byte[].class), isA(CatalogRequestMessage.class)))
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
                 .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 5))
                 .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog))); // this is important, otherwise there is an endless loop!
 
@@ -312,7 +313,7 @@ public class CatalogRuntimeComponentTest {
                     directory.insert(node);
 
                     var numAssets = 1 + rnd.nextInt(10);
-                    when(dispatcher.dispatch(eq(byte[].class), argThat(sentTo(nodeId, nodeUrl))))
+                    when(dispatcher.dispatch(any(), eq(byte[].class), argThat(sentTo(nodeId, nodeUrl))))
                             .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), "catalog-" + nodeUrl, numAssets));
                     numTotalAssets.addAndGet(numAssets);
                 });
@@ -337,11 +338,11 @@ public class CatalogRuntimeComponentTest {
         directory.insert(node2);
         reg.register(DATASPACE_PROTOCOL, dispatcher);
 
-        when(dispatcher.dispatch(eq(byte[].class), argThat(sentTo(node1.id(), node1.targetUrl()))))
+        when(dispatcher.dispatch(any(), eq(byte[].class), argThat(sentTo(node1.id(), node1.targetUrl()))))
                 .thenReturn(catalogOf(catalog -> toBytes(ttr, catalog), "catalog-" + node1.targetUrl(), createDataset("offer1"), createDataset("offer2"), createDataset("offer3")))
                 .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog)));
 
-        when(dispatcher.dispatch(eq(byte[].class), argThat(sentTo(node2.id(), node2.targetUrl()))))
+        when(dispatcher.dispatch(any(), eq(byte[].class), argThat(sentTo(node2.id(), node2.targetUrl()))))
                 .thenReturn(catalogOf(catalog -> toBytes(ttr, catalog), "catalog-" + node2.targetUrl(), createDataset("offer14"), createDataset("offer32"), /*this one is conflicting:*/createDataset("offer3")))
                 .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog)));
 


### PR DESCRIPTION
## What this PR changes/adds

Fix after upstream changes. It currently inject a single participant into the crawler, which makes it compatibile
with single participant context EDC. We could think about allowing the federated catalog to be used within a multi participant context scenario

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
