### PR TITLE
fix: 2025-1 catalog crawling

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -7,15 +7,7 @@ on:
     types: [ opened ]
 
 jobs:
-  add-comment:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/first-interaction@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
-          pr-message: >-
-            We are always happy to welcome new contributors :heart: To make things easier for everyone, please
-            make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md),
-            check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
-            relate this pull request to an existing issue or discussion.
+  trigger-workflow:
+    uses: eclipse-edc/.github/.github/workflows/first-interaction.yml@main
+    secrets:
+      envGH: ${{ secrets.GITHUB_TOKEN }}

--- a/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
+++ b/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
@@ -97,7 +97,7 @@ public class ExecutionManager {
             if (adapter.isEmpty()) {
                 monitor.warning(format("No protocol adapter found for protocol '%s'", item.getProtocol()));
             } else {
-                var updateRequest = new UpdateRequest(item.getId(), item.getUrl());
+                var updateRequest = new UpdateRequest(item.getId(), item.getUrl(), item.getProtocol());
                 adapter.get().apply(updateRequest)
                         .thenAccept(successHandler)
                         .whenComplete((v, throwable) -> onCompletion(item, throwable));

--- a/core/federated-catalog-core-08/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtensionTest.java
+++ b/core/federated-catalog-core-08/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtensionTest.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.catalog.cache.query.DspCatalogRequestAction;
 import org.eclipse.edc.catalog.crawler.RecurringExecutionPlan;
 import org.eclipse.edc.catalog.spi.CatalogConstants;
 import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
 import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
 import org.eclipse.edc.crawler.spi.TargetNodeFilter;
 import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
@@ -32,15 +33,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class FederatedCatalogCacheExtensionTest {
     private final FederatedCatalogCache storeMock = mock();
     private final TargetNodeDirectory nodeDirectoryMock = mock();
+    private final CrawlerActionRegistry crawlerActionRegistry = mock();
     private FederatedCatalogCacheExtension extension;
 
     @BeforeEach
@@ -55,6 +59,7 @@ class FederatedCatalogCacheExtensionTest {
         context.registerService(ExecutionPlan.class, new RecurringExecutionPlan(Duration.ofSeconds(1), Duration.ofSeconds(0), mock()));
         context.registerService(TypeManager.class, mock());
         context.registerService(Monitor.class, monitor);
+        context.registerService(CrawlerActionRegistry.class, crawlerActionRegistry);
 
         extension = factory.constructInstance(FederatedCatalogCacheExtension.class);
     }
@@ -65,11 +70,10 @@ class FederatedCatalogCacheExtensionTest {
     }
 
     @Test
-    void verifyProvider_cacheNodeAdapterRegistry(ServiceExtensionContext context) {
-        var n = extension.createNodeQueryAdapterRegistry(context);
-        assertThat(extension.createNodeQueryAdapterRegistry(context)).isSameAs(n);
-        assertThat(n.findForProtocol(CatalogConstants.DATASPACE_PROTOCOL)).hasSize(1)
-                .allSatisfy(qa -> assertThat(qa).isInstanceOf(DspCatalogRequestAction.class));
+    void verifyProvider_cacheNodeAdapterRegistry(FederatedCatalogCacheExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(crawlerActionRegistry).register(eq(CatalogConstants.DATASPACE_PROTOCOL), isA(DspCatalogRequestAction.class));
     }
 
 }

--- a/core/federated-catalog-core-08/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
+++ b/core/federated-catalog-core-08/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
@@ -36,6 +36,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.catalog.TestUtil.createCatalog;
 import static org.eclipse.edc.catalog.TestUtil.registerTransformers;
+import static org.eclipse.edc.catalog.spi.CatalogConstants.DATASPACE_PROTOCOL;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,7 +59,7 @@ class DspCatalogRequestActionTest {
 
     @Test
     void apply_withFlatCatalog() {
-        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL);
 
         var catalog = toBytes(createCatalog("test-catalog-id"));
         when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
@@ -76,7 +77,7 @@ class DspCatalogRequestActionTest {
 
     @Test
     void apply_withOnlyNestedCatalog() {
-        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL);
 
         var rootCatalog = createCatalog("root-catalog-id");
         rootCatalog.getDatasets().clear();
@@ -100,7 +101,7 @@ class DspCatalogRequestActionTest {
 
     @Test
     void apply_withRootDatasets_andNestedCatalog() {
-        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL);
 
         var rootCatalog = createCatalog("root-catalog-id");
         var nestedCatalog = createCatalog("nested-catalog-id");

--- a/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
@@ -16,7 +16,6 @@
 package org.eclipse.edc.catalog.cache;
 
 import jakarta.json.Json;
-import org.eclipse.edc.catalog.cache.crawler.CrawlerActionRegistryImpl;
 import org.eclipse.edc.catalog.cache.query.DspCatalogRequestAction;
 import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
 import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
@@ -34,7 +33,6 @@ import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistrib
 import org.eclipse.edc.protocol.dsp.catalog.transform.v2025.from.JsonObjectFromCatalogV2025Transformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -46,7 +44,7 @@ import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransf
 
 import java.util.Map;
 
-import static org.eclipse.edc.catalog.spi.CatalogConstants.DATASPACE_PROTOCOL;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
@@ -58,7 +56,8 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
 
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
-    private CrawlerActionRegistryImpl nodeQueryAdapterRegistry;
+    @Inject
+    private CrawlerActionRegistry crawlerActionRegistry;
     @Inject
     private TypeManager typeManager;
     @Inject
@@ -79,21 +78,15 @@ public class FederatedCatalogCacheExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        registerTransformers(context);
+        registerTransformers();
+
+        var mapper = typeManager.getMapper(JSON_LD);
+        var dspTransformerRegistry = registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+        var adapter = new DspCatalogRequestAction(dispatcherRegistry, participantContextSupplier, context.getMonitor(), mapper, dspTransformerRegistry, jsonLdService);
+        crawlerActionRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, adapter);
     }
 
-    @Provider
-    public CrawlerActionRegistry createNodeQueryAdapterRegistry(ServiceExtensionContext context) {
-        if (nodeQueryAdapterRegistry == null) {
-            nodeQueryAdapterRegistry = new CrawlerActionRegistryImpl();
-            // catalog queries via IDS multipart and DSP are supported by default
-            var mapper = typeManager.getMapper(JSON_LD);
-            nodeQueryAdapterRegistry.register(DATASPACE_PROTOCOL, new DspCatalogRequestAction(dispatcherRegistry, participantContextSupplier, context.getMonitor(), mapper, registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1), jsonLdService));
-        }
-        return nodeQueryAdapterRegistry;
-    }
-
-    private void registerTransformers(ServiceExtensionContext context) {
+    private void registerTransformers() {
         transformerRegistry.register(new JsonObjectToCatalogTransformer());
         transformerRegistry.register(new JsonObjectToDatasetTransformer());
         transformerRegistry.register(new JsonObjectToDataServiceTransformer());

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtensionTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtensionTest.java
@@ -17,8 +17,8 @@ package org.eclipse.edc.catalog.cache;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.catalog.cache.query.DspCatalogRequestAction;
 import org.eclipse.edc.catalog.crawler.RecurringExecutionPlan;
-import org.eclipse.edc.catalog.spi.CatalogConstants;
 import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
 import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
 import org.eclipse.edc.crawler.spi.TargetNodeFilter;
 import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
@@ -34,8 +34,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.Duration;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,6 +48,7 @@ import static org.mockito.Mockito.when;
 class FederatedCatalogCacheExtensionTest {
     private final FederatedCatalogCache storeMock = mock();
     private final TargetNodeDirectory nodeDirectoryMock = mock();
+    private final CrawlerActionRegistry crawlerActionRegistry = mock();
     private FederatedCatalogCacheExtension extension;
 
     @BeforeEach
@@ -60,6 +63,7 @@ class FederatedCatalogCacheExtensionTest {
         context.registerService(ExecutionPlan.class, new RecurringExecutionPlan(Duration.ofSeconds(1), Duration.ofSeconds(0), mock()));
         context.registerService(TypeManager.class, mock());
         context.registerService(Monitor.class, monitor);
+        context.registerService(CrawlerActionRegistry.class, crawlerActionRegistry);
 
         extension = factory.constructInstance(FederatedCatalogCacheExtension.class);
     }
@@ -92,11 +96,10 @@ class FederatedCatalogCacheExtensionTest {
     }
 
     @Test
-    void verifyProvider_cacheNodeAdapterRegistry(ServiceExtensionContext context) {
-        var n = extension.createNodeQueryAdapterRegistry(context);
-        assertThat(extension.createNodeQueryAdapterRegistry(context)).isSameAs(n);
-        assertThat(n.findForProtocol(CatalogConstants.DATASPACE_PROTOCOL)).hasSize(1)
-                .allSatisfy(qa -> assertThat(qa).isInstanceOf(DspCatalogRequestAction.class));
+    void verifyProvider_cacheNodeAdapterRegistry(FederatedCatalogCacheExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(crawlerActionRegistry).register(eq(DATASPACE_PROTOCOL_HTTP_V_2025_1), isA(DspCatalogRequestAction.class));
     }
 
 }

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.catalog.TestUtil.createCatalog;
 import static org.eclipse.edc.catalog.TestUtil.registerTransformers;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -58,7 +59,7 @@ class DspCatalogRequestActionTest {
 
     @Test
     void apply_withFlatCatalog() {
-        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL_HTTP_V_2025_1);
 
         var catalog = toBytes(createCatalog("test-catalog-id"));
         when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
@@ -76,7 +77,7 @@ class DspCatalogRequestActionTest {
 
     @Test
     void apply_withOnlyNestedCatalog() {
-        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL_HTTP_V_2025_1);
 
         var rootCatalog = createCatalog("root-catalog-id");
         rootCatalog.getDatasets().clear();
@@ -100,7 +101,7 @@ class DspCatalogRequestActionTest {
 
     @Test
     void apply_withRootDatasets_andNestedCatalog() {
-        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id");
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL_HTTP_V_2025_1);
 
         var rootCatalog = createCatalog("root-catalog-id");
         var nestedCatalog = createCatalog("nested-catalog-id");

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/query/PagingCatalogFetcherTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/query/PagingCatalogFetcherTest.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.catalog.cache.query.PagingCatalogFetcher;
-import org.eclipse.edc.catalog.spi.CatalogConstants;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
@@ -40,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.catalog.TestUtil.createCatalog;
 import static org.eclipse.edc.catalog.TestUtil.registerTransformers;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -104,7 +104,7 @@ class PagingCatalogFetcherTest {
     private CatalogRequestMessage createRequest() {
         return CatalogRequestMessage.Builder.newInstance()
                 .counterPartyAddress("test-address")
-                .protocol(CatalogConstants.DATASPACE_PROTOCOL)
+                .protocol(DATASPACE_PROTOCOL_HTTP_V_2025_1)
                 .build();
     }
 

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogDefaultServicesExtension.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogDefaultServicesExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.catalog.cache;
 
+import org.eclipse.edc.catalog.cache.crawler.CrawlerActionRegistryImpl;
 import org.eclipse.edc.catalog.cache.query.QueryServiceImpl;
 import org.eclipse.edc.catalog.crawler.RecurringExecutionPlan;
 import org.eclipse.edc.catalog.directory.InMemoryNodeDirectory;
@@ -21,6 +22,7 @@ import org.eclipse.edc.catalog.spi.CatalogCrawlerConfiguration;
 import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
 import org.eclipse.edc.catalog.spi.QueryService;
 import org.eclipse.edc.catalog.store.InMemoryFederatedCatalogCache;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
 import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
 import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
 import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
@@ -66,6 +68,11 @@ public class FederatedCatalogDefaultServicesExtension implements ServiceExtensio
     @Provider
     public QueryService defaultQueryEngine() {
         return new QueryServiceImpl(store);
+    }
+
+    @Provider
+    public CrawlerActionRegistry crawlerActionRegistry() {
+        return new CrawlerActionRegistryImpl();
     }
 
     @Provider(isDefault = true)

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/WorkItem.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/WorkItem.java
@@ -25,18 +25,18 @@ import java.util.List;
 public class WorkItem {
     private final String id;
     private final String url;
-    private final String protocolName;
+    private final String protocol;
     private final List<String> errors;
 
-    public WorkItem(String id, String url, String protocolName) {
+    public WorkItem(String id, String url, String protocol) {
         this.id = id;
         this.url = url;
-        this.protocolName = protocolName;
+        this.protocol = protocol;
         errors = new ArrayList<>();
     }
 
     public String getProtocol() {
-        return protocolName;
+        return protocol;
     }
 
     public String getUrl() {
@@ -60,7 +60,7 @@ public class WorkItem {
         return "WorkItem{" +
                 "id='" + id + '\'' +
                 ", url='" + url + '\'' +
-                ", protocolName='" + protocolName + '\'' +
+                ", protocol='" + protocol + '\'' +
                 ", errors=" + errors +
                 '}';
     }

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/UpdateRequest.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/UpdateRequest.java
@@ -20,5 +20,5 @@ import org.eclipse.edc.crawler.spi.CrawlerAction;
 /**
  * {@link CrawlerAction}s accept {@code UpdateRequests} to execute
  */
-public record UpdateRequest(String nodeId, String nodeUrl) {
+public record UpdateRequest(String nodeId, String nodeUrl, String protocol) {
 }

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogConstants.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogConstants.java
@@ -19,5 +19,6 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 public interface CatalogConstants {
     String PROPERTY_ORIGINATOR = EDC_NAMESPACE + "originator";
+    @Deprecated(since = "0.14.1")
     String DATASPACE_PROTOCOL = "dataspace-protocol-http";
 }

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
@@ -22,13 +22,10 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.catalog.spi.CatalogConstants;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
-import org.eclipse.edc.crawler.spi.TargetNode;
-import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.policy.model.Policy;
@@ -48,7 +45,6 @@ import java.util.stream.IntStream;
 
 import static io.restassured.RestAssured.given;
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -98,10 +94,6 @@ public class TestFunctions {
                 .id(id)
                 .datasets(IntStream.range(0, howManyDatasets).mapToObj(i -> createDataset("DataSet_" + UUID.randomUUID())).collect(toList()))
                 .build()));
-    }
-
-    public static void insertSingle(TargetNodeDirectory directory) {
-        directory.insert(new TargetNode("test-node", "did:web:" + UUID.randomUUID(), "http://test-node.com", singletonList(CatalogConstants.DATASPACE_PROTOCOL)));
     }
 
     public static List<Catalog> queryCatalogApi(Function<JsonObject, Catalog> transformerFunction) {

--- a/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/instrumentation/MockInjectionExtension.java
+++ b/system-tests/component-tests/src/test/java/org/eclipse/edc/catalog/instrumentation/MockInjectionExtension.java
@@ -22,7 +22,7 @@ import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
-import static org.eclipse.edc.catalog.spi.CatalogConstants.DATASPACE_PROTOCOL;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.mockito.Mockito.mock;
 
 public class MockInjectionExtension implements ServiceExtension {
@@ -33,7 +33,7 @@ public class MockInjectionExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        registry.register(DATASPACE_PROTOCOL, createDispatcher());
+        registry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, createDispatcher());
     }
 
     @Provider

--- a/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
+++ b/system-tests/end2end-test/e2e-junit-runner/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     testImplementation(libs.edc.lib.json.ld)
     testImplementation(libs.jackson.jsr310)
 
+    testCompileOnly(project(":launchers:catalog-mocked"))
     testCompileOnly(project(":system-tests:end2end-test:catalog-runtime"))
     testCompileOnly(project(":system-tests:end2end-test:connector-runtime"))
 }

--- a/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.end2end;
 
 import jakarta.json.Json;
-import org.eclipse.edc.catalog.spi.CatalogConstants;
 import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
 import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
 import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
@@ -67,7 +66,9 @@ import static org.eclipse.edc.connector.controlplane.transform.odrl.OdrlTransfor
 import static org.eclipse.edc.end2end.TestFunctions.createContractDef;
 import static org.eclipse.edc.end2end.TestFunctions.createPolicy;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_VERSION;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.Mockito.mock;
@@ -149,7 +150,11 @@ class FederatedCatalogTest {
         typeTransformerRegistry.register(new JsonObjectToDistributionTransformer());
         typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(mapper, JSON_LD));
 
-        var node = new TargetNode("connector", "did:web:" + UUID.randomUUID(), "http://localhost:%s%s".formatted(CONNECTOR_PROTOCOL.port(), CONNECTOR_PROTOCOL.path()), List.of(CatalogConstants.DATASPACE_PROTOCOL));
+        var node = new TargetNode(
+                "connector", "did:web:" + UUID.randomUUID(),
+                "http://localhost:%s%s".formatted(CONNECTOR_PROTOCOL.port(), CONNECTOR_PROTOCOL.path() + "/" + V_2025_1_VERSION),
+                List.of(DATASPACE_PROTOCOL_HTTP_V_2025_1)
+        );
         catalog.registerSystemExtension(ServiceExtension.class, new SeedNodeExtension(node));
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Fix crawling for 2025/1 protocol

## Why it does that

bugfix

## Further notes
- the old protocol was hardcoded in different places, still the implementation needs some love as it is unnecessarily complex, but at least the protocol version now it is set correctly


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #370 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
