### PR TITLE
chore: update DCP module names

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,11 +32,11 @@ edc-dpf-selector-spi = { module = "org.eclipse.edc:data-plane-selector-spi", ver
 edc-ext-http = { module = "org.eclipse.edc:http", version.ref = "edc" }
 edc-iam-mock = { module = "org.eclipse.edc:iam-mock", version.ref = "edc" }
 
-edc-dcp-core = { module = "org.eclipse.edc:identity-trust-core", version.ref = "edc" }
-edc-dcp-issuersconfig = { module = "org.eclipse.edc:identity-trust-issuers-configuration", version.ref = "edc" }
-edc-dcp-service = { module = "org.eclipse.edc:identity-trust-service", version.ref = "edc" }
-edc-dcp-transform = { module = "org.eclipse.edc:identity-trust-transform", version.ref = "edc" }
-edc-dcp-sts-client = { module = "org.eclipse.edc:identity-trust-sts-remote-client", version.ref = "edc" }
+edc-dcp-core = { module = "org.eclipse.edc:decentralized-claims-core", version.ref = "edc" }
+edc-dcp-issuersconfig = { module = "org.eclipse.edc:decentralized-claims-issuers-configuration", version.ref = "edc" }
+edc-dcp-service = { module = "org.eclipse.edc:decentralized-claims-service", version.ref = "edc" }
+edc-dcp-transform = { module = "org.eclipse.edc:decentralized-claims-transform", version.ref = "edc" }
+edc-dcp-sts-client = { module = "org.eclipse.edc:decentralized-claims-sts-remote-client", version.ref = "edc" }
 
 edc-did-core = { module = "org.eclipse.edc:identity-did-core", version.ref = "edc" }
 edc-did-web = { module = "org.eclipse.edc:identity-did-web", version.ref = "edc" }


### PR DESCRIPTION
## What this PR changes/adds

Updates the DCP module names to reflect the renaming done in [this PR](https://github.com/eclipse-edc/Connector/pull/5324).

## Why it does that

correctly referencing dependencies


## Who will sponsor this feature?

me
