### PR TITLE
chore: use first-interaction workflow from .github

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -7,15 +7,7 @@ on:
     types: [ opened ]
 
 jobs:
-  add-comment:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/first-interaction@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
-          pr-message: >-
-            We are always happy to welcome new contributors :heart: To make things easier for everyone, please
-            make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md),
-            check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
-            relate this pull request to an existing issue or discussion.
+  trigger-workflow:
+    uses: eclipse-edc/.github/.github/workflows/first-interaction.yml@main
+    secrets:
+      envGH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What this PR changes/adds

Updates the `first-interaction.yml` to use the worflow from the `.github` repository, as the workflow in this repository was outdated.

## Why it does that

maintainability


## Who will sponsor this feature?

me

