### PR TITLE
docs: fixes broken link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ java -Dweb.http.catalog.path="/api/catalog" \
 ```
 
 this will expose the Catalog API at `http://localhost:8181/api/catalog`. More information about Federated Catalog's APIs
-can be found [here](docs/developer/architecture/federated-catalog-apis).
+can be found [here](docs/developer/architecture/federated-catalog-apis.md).
 
 ### Create the Docker image
 


### PR DESCRIPTION
## What this PR changes/adds
Fixes a broken link on the Repo README

## Why it does that
Because GitHub gave a 404

## Further notes
-

## Who will sponsor this feature?
-

## Linked Issue(s)
-

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
